### PR TITLE
add basic persistence using btcfork.conf file (MVHF-CORE-SW-REQ-2-5 / MVHF-CORE-DES-TRIG-10)

### DIFF
--- a/qa/rpc-tests/mvf-core-trig.py
+++ b/qa/rpc-tests/mvf-core-trig.py
@@ -22,7 +22,7 @@ class MVF_TRIG_Test(BitcoinTestFramework):
         print("Initializing test directory " + self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 4)
 
-    def setup_network(self):
+    def start_all_nodes(self):
         self.nodes = []
         self.is_network_split = False
         self.nodes.append(start_node(0, self.options.tmpdir,
@@ -35,6 +35,15 @@ class MVF_TRIG_Test(BitcoinTestFramework):
         self.nodes.append(start_node(3, self.options.tmpdir,
                             ["-forkheight=300",
                              "-blockversion=%s" % 0x20000002])) # signal SegWit, but forkheight should pre-empt
+
+    def setup_network(self):
+        self.start_all_nodes()
+
+    def prior_fork_detected_on_node(self, node=0):
+        """ check in log file if prior fork has been detected and return true/false """
+        nodelog = self.options.tmpdir + "/node%s/regtest/debug.log" % node
+        marker_found = search_file(nodelog, "MVF: found marker config file")
+        return (len(marker_found) > 0)
 
     def is_fork_triggered_on_node(self, node=0):
         """ check in log file if fork has triggered and return true/false """
@@ -49,13 +58,20 @@ class MVF_TRIG_Test(BitcoinTestFramework):
         print "Generating 99 pre-fork blocks"
         for n in xrange(len(self.nodes)):
             self.nodes[n].generate(99)
-            assert_equal(False, self.is_fork_triggered_on_node(n))
+            assert_equal(False, self.is_fork_triggered_on_node(n)
+                                or self.prior_fork_detected_on_node(n))
         print "Fork did not trigger prematurely"
 
         # check that fork triggers for nodes 0 and 1 at designated height
         # move all nodes to height 100
         for n in xrange(len(self.nodes)):
             self.nodes[n].generate(1)
+        assert_equal(True,  self.is_fork_triggered_on_node(0))
+        assert_equal(False, self.prior_fork_detected_on_node(0))
+        for n in [1,2,3]:
+            assert_equal(False, self.is_fork_triggered_on_node(n))
+            assert_equal(False, self.prior_fork_detected_on_node(n))
+
         assert_equal(True,   self.is_fork_triggered_on_node(0))
         assert_equal(False,  self.is_fork_triggered_on_node(1))
         assert_equal(False,  self.is_fork_triggered_on_node(2))
@@ -72,9 +88,11 @@ class MVF_TRIG_Test(BitcoinTestFramework):
         # check node 2 triggering around height 431
         # it starts at 100
         self.nodes[2].generate(330)
-        assert_equal(False, self.is_fork_triggered_on_node(2))
+        assert_equal(False, self.is_fork_triggered_on_node(2)
+                            or self.prior_fork_detected_on_node(2))
         self.nodes[2].generate(1)
         assert_equal(True,  self.is_fork_triggered_on_node(2))
+        assert_equal(False, self.prior_fork_detected_on_node(2))
         # block 431 is when fork activation is performed.
         # block 432 is first block where new consensus rules are in effect.
         print "Fork triggered successfully on node 2 (segwit, height 431)"
@@ -82,10 +100,25 @@ class MVF_TRIG_Test(BitcoinTestFramework):
         # check node 3 triggering around height 300
         # move to 299
         self.nodes[3].generate(199)
-        assert_equal(False, self.is_fork_triggered_on_node(3))
+        assert_equal(False, self.is_fork_triggered_on_node(3)
+                            or self.prior_fork_detected_on_node(3))
         self.nodes[3].generate(1)
         assert_equal(True,  self.is_fork_triggered_on_node(3))
+        assert_equal(False, self.prior_fork_detected_on_node(3))
         print "Fork triggered successfully on node 3 (block height 300 ahead of SegWit)"
+
+        # test startup detection of prior fork activation.
+        # by now, all 4 nodes have triggered.
+        print "Stopping all nodes"
+        for n in xrange(4):
+            assert_equal(False, self.prior_fork_detected_on_node(n))
+            stop_node(self.nodes[n], n)
+        # restart them all, check that they detected having forked on prior run
+        print "Restarting all nodes"
+        self.start_all_nodes()
+        for n in xrange(4):
+            assert_equal(True, self.prior_fork_detected_on_node(n))
+        print "Prior fork activation detected on all nodes"
 
 if __name__ == '__main__':
     MVF_TRIG_Test().main()

--- a/qa/rpc-tests/walletbackupauto.py
+++ b/qa/rpc-tests/walletbackupauto.py
@@ -312,6 +312,8 @@ class WalletBackupTest(BitcoinTestFramework):
         # rewind node 2's chain to before backupblock
         logging.info("Stopping all nodes")
         self.stop_four()
+        for n in xrange(4):
+            os.unlink(os.path.join(tmpdir,"node%s" % n,"btcfork.conf"))
         logging.info("Erasing blockchain on node 2 while keeping backup file")
         shutil.rmtree(self.options.tmpdir + "/node2/regtest/blocks")
         shutil.rmtree(self.options.tmpdir + "/node2/regtest/chainstate")
@@ -337,6 +339,7 @@ class WalletBackupTest(BitcoinTestFramework):
         assert_equal(node2backupfile_orig_md5,hashlib.md5(open(os.path.join(tmpdir,"node2","regtest","newreldir",old_files_found[0]), 'rb').read()).hexdigest())
         logging.info("Checksum ok - shutting down")
         stop_node(self.nodes[2], 2)
+        os.unlink(os.path.join(tmpdir,"node2","btcfork.conf"))
         self.start_four()
 
         # test that wallet backup is not performed again if fork has already
@@ -350,6 +353,7 @@ class WalletBackupTest(BitcoinTestFramework):
         os.remove(node1backupfile)
         # check that no wallet backup file created
         logging.info("restarting node 1")
+        os.unlink(os.path.join(tmpdir,"node1","btcfork.conf"))
         self.nodes[1] = start_node(1, self.options.tmpdir, ["-keypool=100",
                                                             "-autobackupwalletpath=filenameonly.@.bak",
                                                             "-autobackupblock=%s"%(backupblock)])

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1636,11 +1636,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // MVF-Core begin
     else {
         // check if we're past the auto backup block height or fork height
-        if (chainActive.Height() >= FinalActivateForkHeight
+        if (wasMVFHardForkPreviouslyActivated || chainActive.Height() >= FinalActivateForkHeight
             || chainActive.Height() > GetArg("-autobackupblock", FinalActivateForkHeight - 1))
             // MVF-Core TODO: check if SegWit is already active at height. A bit tricky at this point since versionbitscache is in main.cpp.
         {
-            LogPrintf("MVF: AppInit2: ChainActive.Tip() exceeds fork activation height at startup - disabling wallet backup\n");
+            LogPrintf("MVF: AppInit2: Fork already activated or ChainActive.Tip() exceeds fork activation height at startup - disabling wallet backup\n");
             fAutoBackupDone = true;
             // MVF-Core TODO: perform any other init actions needed
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2608,7 +2608,7 @@ void static UpdateTip(CBlockIndex *pindexNew) {
     } // if (!fAutoBackupDone)
 
     // if trigger block height reached or SegWit soft-fork activated, perform hardfork activation actions (MVHF-CORE-DES-TRIG-6)
-    if (!isMVFHardForkActive && ((chainActive.Height() == FinalActivateForkHeight)
+    if (!wasMVFHardForkPreviouslyActivated && !isMVFHardForkActive && ((chainActive.Height() == FinalActivateForkHeight)
                                    || VersionBitsTipState(chainParams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
     {
         // MVF-Core TODO: decide on above condition
@@ -3865,7 +3865,7 @@ bool static LoadBlockIndexDB()
 
     // MVF-Core begin
     // check if hardfork needs activating
-    if (!isMVFHardForkActive && (chainActive.Height() > FinalActivateForkHeight
+    if (!wasMVFHardForkPreviouslyActivated && !isMVFHardForkActive && (chainActive.Height() > FinalActivateForkHeight
                                  || VersionBitsTipState(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
     {
         ActivateFork();

--- a/src/mvf-core.cpp
+++ b/src/mvf-core.cpp
@@ -8,6 +8,10 @@
 #include "util.h"
 #include "chainparams.h"
 
+#include <iostream>
+#include <fstream>
+#include <boost/filesystem.hpp>
+
 using namespace std;
 
 // actual fork height, taking into account user configuration parameters (MVHF-CORE-DES-TRIG-4)
@@ -15,6 +19,10 @@ int FinalActivateForkHeight = 0;
 
 // actual fork id, taking into account user configuration parameters (MVHF-CORE-DES-CSIG-1)
 int FinalForkId = 0;
+
+// track whether HF has been activated before in previous run (MVHF-CORE-DES-TRIG-5)
+// is set at startup based on btcfork.conf presence
+bool wasMVFHardForkPreviouslyActivated = false;
 
 // track whether HF is active (MVHF-CORE-DES-TRIG-5)
 bool isMVFHardForkActive = false;
@@ -88,12 +96,25 @@ void ForkSetup(const CChainParams& chainparams)
         }
     }
 
-    // we should always set the activation flag to false during setup
-    isMVFHardForkActive = false;
-
     LogPrintf("%s: MVF: active fork height = %d\n", __func__, FinalActivateForkHeight);
     LogPrintf("%s: MVF: active fork id = 0x%06x (%d)\n", __func__, FinalForkId, FinalForkId);
     LogPrintf("%s: MVF: auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalForkId - 1));
+
+    // check if btcfork.conf exists (MVHF-CORE-DES-TRIG-10)
+    boost::filesystem::path pathBTCforkConfigFile(BTCFORK_CONF_FILENAME);
+    if (!pathBTCforkConfigFile.is_complete())
+        pathBTCforkConfigFile = GetDataDir(false) / pathBTCforkConfigFile;
+    if (boost::filesystem::exists(pathBTCforkConfigFile)) {
+        LogPrintf("%s: MVF: found marker config file at %s - client has already forked before\n", __func__, pathBTCforkConfigFile.string().c_str());
+        wasMVFHardForkPreviouslyActivated = true;
+    }
+    else {
+        LogPrintf("%s: MVF: no marker config file at %s - client has not forked yet\n", __func__, pathBTCforkConfigFile.string().c_str());
+        wasMVFHardForkPreviouslyActivated = false;
+    }
+
+    // we should always set the activation flag to false during setup
+    isMVFHardForkActive = false;
 }
 
 
@@ -101,9 +122,38 @@ void ForkSetup(const CChainParams& chainparams)
 void ActivateFork(void)
 {
     LogPrintf("%s: MVF: checking whether to perform fork activation\n", __func__);
-    if (!isMVFHardForkActive)  // sanity check
+    if (!isMVFHardForkActive && !wasMVFHardForkPreviouslyActivated)  // sanity check
     {
         LogPrintf("%s: MVF: performing fork activation actions\n", __func__);
+
+        boost::filesystem::path pathBTCforkConfigFile(BTCFORK_CONF_FILENAME);
+        if (!pathBTCforkConfigFile.is_complete())
+            pathBTCforkConfigFile = GetDataDir(false) / pathBTCforkConfigFile;
+
+        LogPrintf("%s: MVF: checking for existence of %s\n", __func__, pathBTCforkConfigFile.string().c_str());
+
+        // remove btcfork.conf if it already exists - it shall be overwritten
+        if (boost::filesystem::exists(pathBTCforkConfigFile)) {
+            LogPrintf("%s: MVF: removing %s\n", __func__, pathBTCforkConfigFile.string().c_str());
+            try {
+                boost::filesystem::remove(pathBTCforkConfigFile);
+            } catch (const boost::filesystem::filesystem_error& e) {
+                LogPrintf("%s: Unable to remove pidfile: %s\n", __func__, e.what());
+            }
+        }
+        // try to write the btcfork.conf (MVHF-CORE-DES-TRIG-10)
+        LogPrintf("%s: MVF: writing %s\n", __func__, pathBTCforkConfigFile.string().c_str());
+        std::ofstream  btcforkfile(pathBTCforkConfigFile.string().c_str(), std::ios::out);
+        btcforkfile << "forkheight=" << FinalActivateForkHeight << "\n";
+        btcforkfile << "forkid=" << FinalForkId << "\n";
+        btcforkfile << "autobackupblock=" << GetArg("-autobackupblock", FinalActivateForkHeight - 1) << "\n";
+        btcforkfile.close();
+
+        LogPrintf("%s: MVF: active fork height = %d\n", __func__, FinalActivateForkHeight);
+        LogPrintf("%s: MVF: active fork id = 0x%06x (%d)\n", __func__, FinalForkId, FinalForkId);
+        LogPrintf("%s: MVF: auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalForkId - 1));
+
+        // set the flag so that other code knows HF is active
         isMVFHardForkActive = true;
     }
 }

--- a/src/mvf-core.h
+++ b/src/mvf-core.h
@@ -11,7 +11,7 @@
 class CChainParams;
 
 extern int FinalActivateForkHeight;             // MVHF-CORE-DES-TRIG-4
-extern bool wasMVFHardForkPreviouslyActivated;  // MVHF-BU-DES-TRIG-5
+extern bool wasMVFHardForkPreviouslyActivated;  // MVHF-CORE-DES-TRIG-5
 extern bool isMVFHardForkActive;                // MVHF-CORE-DES-TRIG-5
 extern int FinalForkId;                         // MVHF-CORE-DES-CSIG-1
 extern bool fAutoBackupDone;                    // MVHF-CORE-DES-WABU-1

--- a/src/mvf-core.h
+++ b/src/mvf-core.h
@@ -10,11 +10,12 @@
 
 class CChainParams;
 
-extern int FinalActivateForkHeight;         // MVHF-CORE-DES-TRIG-4
-extern bool isMVFHardForkActive;            // MVHF-CORE-DES-TRIG-5
-extern int FinalForkId;                     // MVHF-CORE-DES-CSIG-1
-extern bool fAutoBackupDone;                // MVHF-CORE-DES-WABU-1
-extern std::string autoWalletBackupSuffix;  // MVHF-CORE-DES-WABU-1
+extern int FinalActivateForkHeight;             // MVHF-CORE-DES-TRIG-4
+extern bool wasMVFHardForkPreviouslyActivated;  // MVHF-BU-DES-TRIG-5
+extern bool isMVFHardForkActive;                // MVHF-CORE-DES-TRIG-5
+extern int FinalForkId;                         // MVHF-CORE-DES-CSIG-1
+extern bool fAutoBackupDone;                    // MVHF-CORE-DES-WABU-1
+extern std::string autoWalletBackupSuffix;      // MVHF-CORE-DES-WABU-1
 
 
 // default values that can be easily put into an enum
@@ -58,6 +59,8 @@ static const uint256 HARDFORK_POWRESET_MAINNET = uint256S("00007ffffffffffffffff
                      HARDFORK_POWRESET_TESTNET = uint256S("007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // testnet
                      HARDFORK_POWRESET_REGTEST = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");  // regtestnet
 
+// MVHF-CORE-DES-TRIG-10 - config file that is written when forking, and used to detect "forked" condition at start
+const char * const BTCFORK_CONF_FILENAME = "btcfork.conf";
 
 extern std::string ForkCmdLineHelp();  // fork-specific command line option help (MVHF-CORE-DES-TRIG-8)
 extern void ForkSetup(const CChainParams& chainparams);  // actions to perform at program setup (parameter validation etc.)


### PR DESCRIPTION
Add basic persistence using btcfork.conf file (MVHF-CORE-SW-REQ-2-5 / MVHF-CORE-DES-TRIG-10)

The settings stored in the config file are not read back in during program 
initialization. This might be necessary later on, to determine whether the
forkport setting (to be added) matches the port setting or not.

A mismatch would be an indication to prefer the forkport setting in order to
connect to the forked network.

Whether or not the fork has been activated in a prior run is stored in the global
variable 'wasMVFHardForkPreviouslyActivated'.

The mvf-core-trig.py and walletbackupauto.py tests are extended:
- mvf-core-trig.py now tests whether the fork file is written and the detection works
- the wallet backup tests remove the btcfork.conf prior to node restarts so that they can test the .old file writing correctly

In future, the application should probably output a message at startup/shutdown and
in the GUI if it detects this file, to prompt the user to integrate the relevant settings into
the main configuration file (bitcoin.conf).