### PR TITLE
fixes to enable isMVFHardForkActive when re-triggering

### DIFF
--- a/qa/rpc-tests/mvf-core-trig.py
+++ b/qa/rpc-tests/mvf-core-trig.py
@@ -12,6 +12,8 @@
 # on node 3, test block height trigger pre-empts SegWit trigger at 300
 #
 
+import os
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
@@ -49,7 +51,8 @@ class MVF_TRIG_Test(BitcoinTestFramework):
         """ check in log file if fork has triggered and return true/false """
         # MVF-Core TODO: extend to check using RPC info about forks
         nodelog = self.options.tmpdir + "/node%s/regtest/debug.log" % node
-        hf_active = search_file(nodelog, "isMVFHardForkActive=1")
+        hf_active = (search_file(nodelog, "isMVFHardForkActive=1") and
+                     search_file(nodelog, "setting isMVFHardForkActive"))
         fork_actions_performed = search_file(nodelog, "MVF: performing fork activation actions")
         return (len(hf_active) > 0 and len(fork_actions_performed) == 1)
 
@@ -113,6 +116,9 @@ class MVF_TRIG_Test(BitcoinTestFramework):
         for n in xrange(4):
             assert_equal(False, self.prior_fork_detected_on_node(n))
             stop_node(self.nodes[n], n)
+            # get rid of debug.log files so we can better check retrigger
+            os.unlink(os.path.join(self.options.tmpdir,"node%d" % n,"regtest","debug.log"))
+
         # restart them all, check that they detected having forked on prior run
         print "Restarting all nodes"
         self.start_all_nodes()

--- a/qa/rpc-tests/mvf-core-trig.py
+++ b/qa/rpc-tests/mvf-core-trig.py
@@ -52,7 +52,7 @@ class MVF_TRIG_Test(BitcoinTestFramework):
         # MVF-Core TODO: extend to check using RPC info about forks
         nodelog = self.options.tmpdir + "/node%s/regtest/debug.log" % node
         hf_active = (search_file(nodelog, "isMVFHardForkActive=1") and
-                     search_file(nodelog, "setting isMVFHardForkActive"))
+                     search_file(nodelog, "enabling isMVFHardForkActive"))
         fork_actions_performed = search_file(nodelog, "MVF: performing fork activation actions")
         return (len(hf_active) > 0 and len(fork_actions_performed) == 1)
 
@@ -124,6 +124,8 @@ class MVF_TRIG_Test(BitcoinTestFramework):
         self.start_all_nodes()
         for n in xrange(4):
             assert_equal(True, self.prior_fork_detected_on_node(n))
+            nodelog=os.path.join(self.options.tmpdir,"node%d" % n,"regtest","debug.log")
+            assert(len(search_file(nodelog, "enabling isMVFHardForkActive")) == 1)
         print "Prior fork activation detected on all nodes"
 
 if __name__ == '__main__':

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3865,7 +3865,7 @@ bool static LoadBlockIndexDB()
 
     // MVF-Core begin
     // check if hardfork needs activating
-    if (!isMVFHardForkActive && (chainActive.Height() > FinalActivateForkHeight
+    if (!isMVFHardForkActive && (chainActive.Height() >= FinalActivateForkHeight
                              || VersionBitsTipState(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
     {
         ActivateFork();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2608,8 +2608,8 @@ void static UpdateTip(CBlockIndex *pindexNew) {
     } // if (!fAutoBackupDone)
 
     // if trigger block height reached or SegWit soft-fork activated, perform hardfork activation actions (MVHF-CORE-DES-TRIG-6)
-    if (!wasMVFHardForkPreviouslyActivated && !isMVFHardForkActive && ((chainActive.Height() == FinalActivateForkHeight)
-                                   || VersionBitsTipState(chainParams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
+    if (!isMVFHardForkActive && ((chainActive.Height() == FinalActivateForkHeight)
+                             || VersionBitsTipState(chainParams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
     {
         // MVF-Core TODO: decide on above condition
         // if preparations are only made after block has been accepted, then only FinalActivateForkHeight+1 can be new rules
@@ -3865,8 +3865,8 @@ bool static LoadBlockIndexDB()
 
     // MVF-Core begin
     // check if hardfork needs activating
-    if (!wasMVFHardForkPreviouslyActivated && !isMVFHardForkActive && (chainActive.Height() > FinalActivateForkHeight
-                                 || VersionBitsTipState(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
+    if (!isMVFHardForkActive && (chainActive.Height() > FinalActivateForkHeight
+                             || VersionBitsTipState(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
     {
         ActivateFork();
     }

--- a/src/mvf-core.cpp
+++ b/src/mvf-core.cpp
@@ -122,7 +122,7 @@ void ForkSetup(const CChainParams& chainparams)
 void ActivateFork(void)
 {
     LogPrintf("%s: MVF: checking whether to perform fork activation\n", __func__);
-    if (!isMVFHardForkActive && !wasMVFHardForkPreviouslyActivated)  // sanity check
+    if (!isMVFHardForkActive && !wasMVFHardForkPreviouslyActivated)  // sanity check to protect the one-off actions
     {
         LogPrintf("%s: MVF: performing fork activation actions\n", __func__);
 
@@ -152,10 +152,10 @@ void ActivateFork(void)
         LogPrintf("%s: MVF: active fork height = %d\n", __func__, FinalActivateForkHeight);
         LogPrintf("%s: MVF: active fork id = 0x%06x (%d)\n", __func__, FinalForkId, FinalForkId);
         LogPrintf("%s: MVF: auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalForkId - 1));
-
-        // set the flag so that other code knows HF is active
-        isMVFHardForkActive = true;
     }
+    // set the flag so that other code knows HF is active
+    LogPrintf("%s: MVF: enabling isMVFHardForkActive\n", __func__);
+    isMVFHardForkActive = true;
 }
 
 
@@ -166,6 +166,7 @@ void DeactivateFork(void)
     if (isMVFHardForkActive)
     {
         LogPrintf("%s: MVF: performing fork deactivation actions\n", __func__);
-        isMVFHardForkActive = false;
     }
+    LogPrintf("%s: MVF: disabling isMVFHardForkActive\n", __func__);
+    isMVFHardForkActive = false;
 }


### PR DESCRIPTION
Also found an off-by-one bug in the triggering condition in LoadBlockIndex.
These need to be backported to MVF-BU as well.