### PR TITLE
add -randomseed option to test framework, so that tests that make use of randomness can simply use it

### DIFF
--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -8,6 +8,8 @@
 # Add python-bitcoinrpc to module search path:
 import os
 import sys
+import time   # MVF-Core
+import random # MVF-Core
 
 import shutil
 import tempfile
@@ -110,8 +112,19 @@ class BitcoinTestFramework(object):
                           help="Print out all RPC calls as they are made")
         parser.add_option("--coveragedir", dest="coveragedir",
                           help="Write tested RPC commands into this directory")
+        # MVF-Core begin added for tests using randomness (e.g. mvf-core-retarget.py)
+        parser.add_option("--randomseed", dest="randomseed",
+                          help="Set RNG seed for tests that use randomness (ignored otherwise)")
+        # MVF-Core end
         self.add_options(parser)
         (self.options, self.args) = parser.parse_args()
+        # MVF-Core begin added for tests using randomness (e.g. mvf-bu-retarget.py)
+        if self.options.randomseed:
+            self.randomseed = int(self.options.randomseed)
+        else:
+            self.randomseed = time.time()
+        random.seed(self.randomseed)
+        # MVF-Core end
 
         if self.options.trace_rpc:
             import logging


### PR DESCRIPTION
This is a merge of https://github.com/BTCfork/hardfork_prototype_1_mvf-bu/commit/788100c3b1d377d95c6312832343054c99ab9895
which has also been submitted in upstream BU  as https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/175 (not yet merged)

Tests can access self.randomseed which is set up after the command line options have been parsed.
First test to use this will be mvf-bu-retarget.py

Later, if there is a crash, you can re-run the test with e.g.

rpc-tests.py --randomseed=12345 mytest