### PR TITLE
add improvements aimed at facilitating Travis and testing of disabled/skipped tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
     - compiler: ": Win32"
       env: HOST=i686-w64-mingw32 PPA="ppa:ubuntu-wine/ppa" PACKAGES="nsis gcc-mingw-w64-i686 g++-mingw-w64-i686 binutils-mingw-w64-i686 mingw-w64-dev wine1.7 bc" RUN_TESTS=true GOAL="deploy" BITCOIN_CONFIG="--enable-gui --enable-reduce-exports" MAKEJOBS="-j2"
     - compiler: ": 32-bit + dash"
-      env: HOST=i686-pc-linux-gnu PACKAGES="g++-multilib bc python-zmq" PPA="ppa:chris-lea/zeromq" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++" USE_SHELL="/bin/dash"
+      env: HOST=i686-pc-linux-gnu PACKAGES="g++-multilib bc python-zmq" DEP_OPTS="NO_QT=1" PPA="ppa:chris-lea/zeromq" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++" USE_SHELL="/bin/dash"
     - compiler: ": Win64"
       env: HOST=x86_64-w64-mingw32 PPA="ppa:ubuntu-wine/ppa" PACKAGES="nsis gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 binutils-mingw-w64-x86-64 mingw-w64-dev wine1.7 bc" RUN_TESTS=true GOAL="deploy" BITCOIN_CONFIG="--enable-gui --enable-reduce-exports" MAKEJOBS="-j2"
     - compiler: ": bitcoind"
@@ -64,7 +64,7 @@ before_script:
 script:
     - if [ -n "$USE_SHELL" ]; then export CONFIG_SHELL="$USE_SHELL"; fi
     - OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
-    - BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib"
+    - BITCOIN_CONFIG_ALL="--without-comparison-tool --disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib"
     - depends/$HOST/native/bin/ccache --max-size=$CCACHE_SIZE
     - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export CCACHE_READONLY=1; fi
     - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh"' || ./autogen.sh
@@ -74,7 +74,7 @@ script:
     - ./configure --cache-file=../config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
     - make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
     - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
-    - if [ "$RUN_TESTS" = "true" ]; then make check; fi
+    - if [ "$RUN_TESTS" = "true" ]; then make $MAKEJOBS check; fi
     - if [ "$RUN_TESTS" = "true" ]; then qa/pull-tester/rpc-tests.py --coverage; fi
 after_script:
     - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then (echo "Upload goes here. Something like: scp -r $BASE_OUTDIR server" || echo "upload failed"); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - CCACHE_TEMPDIR=/tmp/.ccache-temp
     - CCACHE_COMPRESS=1
     - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
-    - SDK_URL=https://bitcoincore.org/depends-sources/sdks
+    - SDK_URL=https://github.com/keo/MacOSX-SDK/releases/download/v0.0
     - PYTHON_DEBUG=1
     - WINEDEBUG=fixme-all
 cache:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Bitcoin Core integration/staging tree
 =====================================
 
-[![Build Status](https://travis-ci.org/bitcoin/bitcoin.svg?branch=master)](https://travis-ci.org/bitcoin/bitcoin)
+[![Build Status](https://travis-ci.org/BTCfork/hardfork_prototype_1_mvf-core.svg?branch=master)](https://travis-ci.org/BTCfork/hardfork_prototype_1_mvf-core)
 
 https://bitcoincore.org
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,6 +1,6 @@
 PACKAGE=qt
 $(package)_version=5.5.0
-$(package)_download_path=http://download.qt.io/official_releases/qt/5.5/$($(package)_version)/submodules
+$(package)_download_path=http://download.qt.io/archive/qt/5.5/$($(package)_version)/submodules
 $(package)_suffix=opensource-src-$($(package)_version).tar.gz
 $(package)_file_name=qtbase-$($(package)_suffix)
 $(package)_sha256_hash=7e82b1318f88e56a2a9376e069aa608d4fd96b48cb0e1b880ae658b0a1af0561

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -55,21 +55,25 @@ ENABLE_COVERAGE=0
 opts = set()
 double_opts = set()  # BU: added for checking validity of -- opts
 passOn = ""
+showHelp = False  # if we need to print help
 p = re.compile("^--")
 # some of the single-dash options applicable only to this runner script
 # are also allowed in double-dash format (but are not passed on to the
 # test scripts themselves)
 private_single_opts = ('-h',
+                       '-f',    # equivalent to -force-enable
                        '-help',
                        '-list',
                        '-extended',
                        '-extended-only',
                        '-only-extended',
+                       '-force-enable',
                        '-win')
 private_double_opts = ('--list',
                        '--extended',
                        '--extended-only',
                        '--only-extended',
+                       '--force-enable',
                        '--win')
 test_script_opts = ('--tracerpc',
                     '--help',
@@ -78,6 +82,7 @@ test_script_opts = ('--tracerpc',
                     '--srcdir',
                     '--tmpdir',
                     '--coveragedir',
+                    '--quick',
                     '--randomseed',
                     '--mineblock',
                     '--testbinary',
@@ -97,11 +102,12 @@ for arg in sys.argv[1:]:
         ENABLE_COVERAGE = 1
     elif (p.match(arg) or arg in ('-h', '-help')):
         if arg not in private_double_opts:
-            if arg == '-help' or arg == '-h':
-                pass_arg = '--help'
+            if arg == '--help' or arg == '-help' or arg == '-h':
+                passOn = '--help'
+                showHelp = True
             else:
-                pass_arg = arg
-            passOn += " " + pass_arg
+                if passOn is not '--help':
+                    passOn += " " + arg
         # add it to double_opts only for validation
         double_opts.add(arg)
     else:
@@ -153,8 +159,7 @@ testScripts = [ RpcTest(t) for t in [
     'mempool_limit',
     'httpbasics',
     'multi_rpc',
-    #Disabled('mvf-core-retarget', "temporary"),  # MVF-Core
-    'mvf-core-retarget',  # MVF-Core
+    'mvf-core-retarget --quick',  # MVF-Core
     'mvf-core-trig',  # MVF-Core
     'zapwallettxes',
     'proxy_test',
@@ -191,6 +196,7 @@ testScriptsExt = [ RpcTest(t) for t in [
     Disabled('pruning', "times out - needs investigation"),
     'forknotify',
     'invalidateblock',
+    'mvf-core-retarget', # MVF-Core: long version of test
     Disabled('rpcbind_test', "temporary, bug in libevent, see #6655"),
     'smartfees',
     'maxblocksinflight',
@@ -215,6 +221,8 @@ def show_wrapper_options():
           "                        run ONLY the extended tests"
     print "  -list / --list        only list test names"
     print "  -win / --win          signal running on Windows and run those tests"
+    print "  -f / -force-enable / --force-enable\n" + \
+          "                        attempt to run disabled/skipped tests"
     print "  -h / -help / --help   print this help"
 
 def runtests():
@@ -225,7 +233,9 @@ def runtests():
     test_failure_info = {}
     disabled = []
     skipped = []
+    tests_to_run = []
 
+    force_enable = option_passed('force-enable') or '-f' in opts
     run_only_extended = option_passed('only-extended') or option_passed('extended-only')
 
     if option_passed('list'):
@@ -250,85 +260,115 @@ def runtests():
         cov_flag = coverage.flag if coverage else ''
         flags = " --srcdir %s/src %s %s" % (buildDir, cov_flag, passOn)
 
-        #Run Tests
-        p = re.compile(" -h| --help| -help")
-        for i in range(len(testScripts)):
-            scriptname=re.sub(".py$", "", str(testScripts[i]).split(' ')[0])
-            fullscriptcmd=str(testScripts[i])
-            if ((len(opts) == 0
-                    or p.match(passOn)
-                    or option_passed('extended')
-                    or option_passed('win')
-                    or scriptname in opts
-                    or (scriptname + '.py') in opts )
-                and not run_only_extended):
+        # compile the list of tests to check
 
-                if testScripts[i].is_disabled():
-                    print("Disabled testscript %s%s%s (reason: %s)" % (bold[1], testScripts[i], bold[0], testScripts[i].reason))
-                    disabled.append(str(testScripts[i]))
-                elif testScripts[i].is_skipped():
-                    print("Skipping testscript %s%s%s on this platform (reason: %s)" % (bold[1], testScripts[i], bold[0], testScripts[i].reason))
-                    skipped.append(str(testScripts[i]))
+        # check for explicit tests
+        if showHelp:
+            tests_to_run = [ testScripts[0] ]
+        else:
+            for o in opts:
+                if not o.startswith('-'):
+                    found = False
+                    for t in testScripts + testScriptsExt:
+                        t_rep = str(t).split(' ')
+                        if (t_rep[0] == o or t_rep[0] == o + '.py') and len(t_rep) > 1:
+                            # it is a test with args - check all args match what was passed, otherwise don't add this test
+                            t_args = t_rep[1:]
+                            all_args_found = True
+                            for targ in t_args:
+                                if not targ in passOn.split(' '):
+                                    all_args_found = False
+                            if all_args_found:
+                                tests_to_run.append(t)
+                                found = True
+                        elif str(t) == o or str(t) == o + '.py':
+                            # it is a test without args - just add it or only add it if no passed on args?
+                            if not passOn:
+                                tests_to_run.append(t)
+                                found = True
+                    if not found:
+                        print "Error: %s is not a known test." % o
+                        sys.exit(1)
+
+        #print "tests after explicit collection:"
+        #print tests_to_run
+
+        # if no explicit tests specified, use the lists
+        if not len(tests_to_run):
+            if run_only_extended:
+                tests_to_run = testScriptsExt
+            else:
+                tests_to_run += testScripts
+                if run_extended:
+                    tests_to_run += testScriptsExt
+
+        #print "tests after general collection:"
+        #print tests_to_run
+
+        # weed out the disabled / skipped tests and print them beforehand
+        # this allows earlier intervention in case a test is unexpectedly
+        # skipped
+        if not force_enable:
+            trimmed_tests_to_run = []
+            for t in tests_to_run:
+                if t.is_disabled():
+                    print("Disabled testscript %s%s%s (reason: %s)" % (bold[1], t, bold[0], t.reason))
+                    disabled.append(str(t))
+                elif t.is_skipped():
+                    print("Skipping testscript %s%s%s on this platform (reason: %s)" % (bold[1], t, bold[0], t.reason))
+                    skipped.append(str(t))
                 else:
-                    # not disabled or skipped - execute test (or print help if requested)
+                    trimmed_tests_to_run.append(t)
+            tests_to_run = trimmed_tests_to_run
 
-                    # print the wrapper-specific help options
-                    if p.match(passOn):
-                        show_wrapper_options()
+        #print "tests after trimming disabled/skipped:"
+        #print tests_to_run
 
-                    if bad_opts_found:
-                        if not ' --help' in passOn:
-                            passOn += ' --help'
+        # now run the tests
+        p = re.compile(" -h| --help| -help")
+        for t in tests_to_run:
+            scriptname=re.sub(".py$", "", str(t).split(' ')[0])
+            fullscriptcmd=str(t)
 
-                    print("Running testscript %s%s%s ..." % (bold[1], testScripts[i], bold[0]))
-                    time0 = time.time()
-                    test_passed[fullscriptcmd] = False
-                    try:
-                        subprocess.check_call(
-                            rpcTestDir + repr(testScripts[i]) + flags, shell=True)
-                        test_passed[fullscriptcmd] = True
-                    except subprocess.CalledProcessError as e:
-                        test_failure_info[fullscriptcmd] = e
-                        #print "CalledProcessError for test %s: %s" % (scriptname, e)
+            # print the wrapper-specific help options
+            if showHelp:
+                show_wrapper_options()
 
-                    # exit if help was called
-                    if p.match(passOn):
-                        sys.exit(0)
-                    else:
-                        execution_time[fullscriptcmd] = int(time.time() - time0)
-                        print "Duration: %s s\n" % execution_time[fullscriptcmd]
+            if bad_opts_found:
+                if not ' --help' in passOn:
+                    passOn += ' --help'
 
-        # Run Extended Tests
-        for i in range(len(testScriptsExt)):
-            scriptname = re.sub(".py$", "", str(testScriptsExt[i]).split(' ')[0])
-            fullscriptcmd=str(testScriptsExt[i])
-            if (run_extended or str(testScriptsExt[i]) in opts
-                    or re.sub(".py$", "", str(testScriptsExt[i])) in opts):
+            if len(double_opts):
+                for additional_opt in fullscriptcmd.split(' ')[1:]:
+                    if additional_opt not in double_opts:
+                        continue
 
-                if testScriptsExt[i].is_disabled():
-                    print("Disabled testscript %s%s%s (reason: %s)" % (bold[1], testScriptsExt[i], bold[0], testScriptsExt[i].reason))
-                    disabled.append(str(testScriptsExt[i]))
-                elif testScripts[i].is_skipped():
-                    print("Skipping testscript %s%s%s on this platform (reason: %s)" % (bold[1], testScriptsExt[i], bold[0], testScriptsExt[i].reason))
-                    skipped.append(str(testScriptsExt[i]))
-                elif fullscriptcmd not in execution_time.keys():
-                    # not disabled, skipped or already executed - run test
-                    print(
-                        "Running 2nd level testscript "
-                        + "%s%s%s ..." % (bold[1], testScriptsExt[i], bold[0]))
-                    time0 = time.time()
-                    test_passed[fullscriptcmd] = False
-                    try:
-                        subprocess.check_call(
-                            rpcTestDir + repr(testScriptsExt[i]) + flags, shell=True)
-                        test_passed[fullscriptcmd] = True
-                    except subprocess.CalledProcessError as e:
-                        test_failure_info[fullscriptcmd] = e
-                        #print "CalledProcessError for test %s: %s" % (scriptname, e)
+            if fullscriptcmd not in execution_time.keys():
+                if t in testScripts:
+                    print("Running testscript %s%s%s ..." % (bold[1], t, bold[0]))
+                else:
+                    print("Running 2nd level testscript "
+                          + "%s%s%s ..." % (bold[1], t, bold[0]))
+
+                time0 = time.time()
+                test_passed[fullscriptcmd] = False
+                try:
+                    subprocess.check_call(
+                        rpcTestDir + repr(t) + flags, shell=True)
+                    test_passed[fullscriptcmd] = True
+                except subprocess.CalledProcessError as e:
+                    test_failure_info[fullscriptcmd] = e
+                    #print "CalledProcessError for test %s: %s" % (scriptname, e)
+
+                # exit if help was called
+                if showHelp:
+                    sys.exit(0)
+                else:
                     execution_time[fullscriptcmd] = int(time.time() - time0)
                     print "Duration: %s s\n" % execution_time[fullscriptcmd]
-                else:
-                    print "Skipping extended test name %s - already executed in regular\n" % scriptname
+
+            else:
+                print "Skipping extended test name %s - already executed in regular\n" % scriptname
 
         if coverage:
             coverage.report_rpc_coverage()
@@ -336,24 +376,25 @@ def runtests():
             print("Cleaning up coverage data")
             coverage.cleanup()
 
-        # show some overall results and aggregates
-        print
-        print "%-50s  Status    Time (s)" % "Test"
-        print '-' * 70
-        for k in sorted(execution_time.keys()):
-            print "%-50s  %-6s    %7s" % (k, "PASS" if test_passed[k] else "FAILED", execution_time[k])
-        for d in disabled:
-            print "%-50s  %-8s" % (d, "DISABLED")
-        for s in skipped:
-            print "%-50s  %-8s" % (s, "SKIPPED")
-        print '-' * 70
-        print "%-44s  Total time (s): %7s" % (" ", sum(execution_time.values()))
+        if not showHelp:
+            # show some overall results and aggregates
+            print
+            print "%-50s  Status    Time (s)" % "Test"
+            print '-' * 70
+            for k in sorted(execution_time.keys()):
+                print "%-50s  %-6s    %7s" % (k, "PASS" if test_passed[k] else "FAILED", execution_time[k])
+            for d in disabled:
+                print "%-50s  %-8s" % (d, "DISABLED")
+            for s in skipped:
+                print "%-50s  %-8s" % (s, "SKIPPED")
+            print '-' * 70
+            print "%-44s  Total time (s): %7s" % (" ", sum(execution_time.values()))
 
-        print
-        print "%d test(s) passed / %d test(s) failed / %d test(s) executed" % (test_passed.values().count(True),
-                                                                   test_passed.values().count(False),
-                                                                   len(test_passed))
-        print "%d test(s) disabled / %d test(s) skipped due to platform" % (len(disabled), len(skipped))
+            print
+            print "%d test(s) passed / %d test(s) failed / %d test(s) executed" % (test_passed.values().count(True),
+                                                                       test_passed.values().count(False),
+                                                                       len(test_passed))
+            print "%d test(s) disabled / %d test(s) skipped due to platform" % (len(disabled), len(skipped))
 
     else:
         print "No rpc tests to run. Wallet, utils, and bitcoind must all be enabled"

--- a/qa/rpc-tests/mvf-core-retarget.py
+++ b/qa/rpc-tests/mvf-core-retarget.py
@@ -19,7 +19,11 @@ from datetime import datetime
 HARDFORK_RETARGET_BLOCKS = 180*144
 FORK_BLOCK = 2017
 
-class MVF_RETARGET_Test(BitcoinTestFramework):
+class MVF_RETARGET_BlockHeight_Test(BitcoinTestFramework):
+
+    def add_options(self, parser):
+        parser.add_option("--quick", dest="quick", default=False, action="store_true",
+        help="Run shortened version of test")
 
     def setup_chain(self):
         print("Initializing test directory " + self.options.tmpdir)
@@ -83,8 +87,16 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
         last_retarget_block_timestamp = self.nodes[0].getblock(best_block_hash, True)['time']
         last_wallclock_timestamp = time.time()
 
+        if self.options.quick:
+            # used for CI - just test one day after fork
+            # this is basically just to test reset and initial response
+            number_of_blocks_to_test_after_fork = 144
+        else:
+            # full range
+            number_of_blocks_to_test_after_fork = HARDFORK_RETARGET_BLOCKS + 2016
+
         # start generating MVF blocks with varying time stamps
-        for n in xrange(HARDFORK_RETARGET_BLOCKS + 2016):
+        for n in xrange(number_of_blocks_to_test_after_fork):
             best_block_hash = self.nodes[0].getbestblockhash()
             best_block = self.nodes[0].getblock(best_block_hash, True)
             prev_block = self.nodes[0].getblock(best_block['previousblockhash'], True)
@@ -205,4 +217,4 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
         #raw_input() # uncomment here to pause shutdown and check the logs
 
 if __name__ == '__main__':
-    MVF_RETARGET_Test().main()
+    MVF_RETARGET_BlockHeight_Test().main()


### PR DESCRIPTION
This mirrors MVF-BU PR : https://github.com/BTCfork/hardfork_prototype_1_mvf-bu/pull/49

The long mvf-core-retarget.py has been moved to the extended section, and it now accepts a --quick argument which runs only a subset of the post-fork retargeting. This brings the test's duration down significantly, hopefully enough to allow us to run Travis with it.

Also added better handling of rpc-tests.py options -- now it is possible to specify a test plus its option on the command line and it will be run correctly (including running the test only with that option, not twice if included in both regular and extended).

A new -force-enable (-f) option is added to execute Disabled/Skipped tests, which is useful when you don't want to permanently re-enable them, but tentatively test them.