### PR TITLE
introduce a fork consensus code id

### DIFF
--- a/src/mvf-core.cpp
+++ b/src/mvf-core.cpp
@@ -15,6 +15,15 @@
 
 using namespace std;
 
+// version string identifying the consensus-relevant algorithmic changes
+// so that a user can quickly see if MVF fork clients are compatible
+// for test purposes (since they may diverge during development/testing).
+// A new value must be chosen whenever there are changes to consensus
+// relevant functionality (excepting things which are parameterized).
+// Values are surnames chosen from the name list of space travelers at
+// https://en.wikipedia.org/wiki/List_of_space_travelers_by_name
+std::string post_fork_consensus_id = "AKIYAMA";
+
 // actual fork height, taking into account user configuration parameters (MVHF-CORE-DES-TRIG-4)
 int FinalActivateForkHeight = 0;
 
@@ -35,7 +44,6 @@ bool fAutoBackupDone = false;
 
 // default suffix to append to wallet filename for auto backup (MVHF-CORE-DES-WABU-1)
 std::string autoWalletBackupSuffix = "auto.@.bak";
-
 
 /** Add MVF-specific command line options (MVHF-CORE-DES-TRIG-8) */
 std::string ForkCmdLineHelp()
@@ -64,6 +72,7 @@ void ForkSetup(const CChainParams& chainparams)
     std:string activeNetworkID = chainparams.NetworkIDString();
 
     LogPrintf("%s: MVF: doing setup\n", __func__);
+    LogPrintf("%s: MVF: consensus version = %s\n", __func__, post_fork_consensus_id);
     LogPrintf("%s: MVF: active network = %s\n", __func__, activeNetworkID);
 
     // determine minimum fork height according to network

--- a/src/mvf-core.cpp
+++ b/src/mvf-core.cpp
@@ -72,7 +72,7 @@ void ForkSetup(const CChainParams& chainparams)
     std:string activeNetworkID = chainparams.NetworkIDString();
 
     LogPrintf("%s: MVF: doing setup\n", __func__);
-    LogPrintf("%s: MVF: consensus version = %s\n", __func__, post_fork_consensus_id);
+    LogPrintf("%s: MVF: fork consensus code = %s\n", __func__, post_fork_consensus_id);
     LogPrintf("%s: MVF: active network = %s\n", __func__, activeNetworkID);
 
     // determine minimum fork height according to network

--- a/src/mvf-core.h
+++ b/src/mvf-core.h
@@ -17,6 +17,9 @@ extern int FinalForkId;                         // MVHF-CORE-DES-CSIG-1
 extern bool fAutoBackupDone;                    // MVHF-CORE-DES-WABU-1
 extern std::string autoWalletBackupSuffix;      // MVHF-CORE-DES-WABU-1
 
+// version string identifying the consensus-relevant algorithmic changes
+// so that a user can quickly see if fork clients are compatible
+extern std::string post_fork_consensus_id;
 
 // default values that can be easily put into an enum
 enum {


### PR DESCRIPTION
To prepare for testnet testing, it will be useful to easily identify builds that are compatible / incompatible w.r.t. their post-fork consensus behaviour.

Builds that have the same consensus code should remain on the same chain as long as their other fork parameters are equal (and in the case of MVF-BU, the emergent-consensus related parameters need to be compatible too).