### PR TITLE
Parameterize fork difficulty drop factor (-diffdrop), extract various defaults from common header to test framework

### DIFF
--- a/qa/rpc-tests/mvf-core-retarget.py
+++ b/qa/rpc-tests/mvf-core-retarget.py
@@ -69,7 +69,7 @@ def CalculateMVFResetWorkRequired(bits):
 
     bnPowLimit = bits2target_int(hex2bin(int2hex(POW_LIMIT)))
     # drop difficulty via factor
-    nDropFactor = 4
+    nDropFactor = HARDFORK_DROPFACTOR_REGTEST_DEFAULT
     # total blocktimes prefork during run_test
     nActualTimespan = ORIGINAL_DIFFADJINTERVAL * PREFORK_BLOCKTIME
     # used reduced target time span while within the re-target period

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -23,6 +23,18 @@ from .authproxy import AuthServiceProxy, JSONRPCException
 
 COVERAGE_DIR = None
 
+# MVF-Core begin read regtest fork params from C files
+_mvf_common_h_fh = open('src/mvf-core.h', 'rt')
+_mvf_common_h_contents = _mvf_common_h_fh.read()
+_mvf_common_h_fh.close()
+
+BTCFORK_CONF_FILENAME = re.search(r'BTCFORK_CONF_FILENAME = "(.*)";', _mvf_common_h_contents).group(1)
+HARDFORK_HEIGHT_REGTEST_DEFAULT = int(re.search(r'HARDFORK_HEIGHT_REGTEST = (\d+)', _mvf_common_h_contents).group(1))
+HARDFORK_PORT_REGTEST_DEFAULT = int(re.search(r'HARDFORK_PORT_REGTEST = (\d+)', _mvf_common_h_contents).group(1))
+HARDFORK_SIGHASH_ID_DEFAULT = int(re.search(r'HARDFORK_SIGHASH_ID = (0x[0-9a-fA-F]+)', _mvf_common_h_contents).group(1), 16)
+HARDFORK_DROPFACTOR_REGTEST_DEFAULT = int(re.search(r'HARDFORK_DROPFACTOR_REGTEST = (\d+)', _mvf_common_h_contents).group(1))
+# MVF-Core end
+
 
 def enable_coverage(dirname):
     """Maintain a log of which RPC calls are made during testing."""

--- a/qa/rpc-tests/walletbackupauto.py
+++ b/qa/rpc-tests/walletbackupauto.py
@@ -320,7 +320,7 @@ class WalletBackupTest(BitcoinTestFramework):
         logging.info("Stopping all nodes")
         self.stop_four()
         for n in xrange(4):
-            os.unlink(os.path.join(tmpdir,"node%s" % n,"btcfork.conf"))
+            os.unlink(os.path.join(tmpdir,"node%s" % n,BTCFORK_CONF_FILENAME))
         logging.info("Erasing blockchain on node 2 while keeping backup file")
         shutil.rmtree(self.options.tmpdir + "/node2/regtest/blocks")
         shutil.rmtree(self.options.tmpdir + "/node2/regtest/chainstate")
@@ -352,7 +352,7 @@ class WalletBackupTest(BitcoinTestFramework):
         self.nodes[2].generate(backupblock+1)
         logging.info("Checksum ok - shutting down")
         stop_node(self.nodes[2], 2)
-        os.unlink(os.path.join(tmpdir,"node2","btcfork.conf"))
+        os.unlink(os.path.join(tmpdir,"node2",BTCFORK_CONF_FILENAME))
         self.start_four()
 
         # test that wallet backup is not performed again if fork has already
@@ -366,7 +366,7 @@ class WalletBackupTest(BitcoinTestFramework):
         os.remove(node1backupfile)
         # check that no wallet backup file created
         logging.info("restarting node 1")
-        os.unlink(os.path.join(tmpdir,"node1","btcfork.conf"))
+        os.unlink(os.path.join(tmpdir,"node1",BTCFORK_CONF_FILENAME))
         self.nodes[1] = start_node(1, self.options.tmpdir, ["-keypool=100",
                                                             "-autobackupwalletpath=filenameonly.@.bak",
                                                             "-forkheight=%s"%(backupblock+1),

--- a/src/mvf-core.cpp
+++ b/src/mvf-core.cpp
@@ -28,6 +28,9 @@ std::string post_fork_consensus_id = "YAMAZAKI";
 // actual fork height, taking into account user configuration parameters (MVHF-CORE-DES-TRIG-4)
 int FinalActivateForkHeight = 0;
 
+// actual difficulty drop factor, taking into account user configuration parameters (MVF-Core TODO: MVHF-CORE-DES-DIAD-?)
+unsigned FinalDifficultyDropFactor = 0;
+
 // actual fork id, taking into account user configuration parameters (MVHF-CORE-DES-CSIG-1)
 int FinalForkId = 0;
 
@@ -63,6 +66,8 @@ std::string ForkCmdLineHelp()
     // fork id (MVHF-CORE-DES-CSIG-1)
     strUsage += HelpMessageOpt("-forkid=<n>", strprintf(_("Fork id to use for signature change. Value must be between 0 and %d. Default is 0x%06x (%u)"), (unsigned)MAX_HARDFORK_SIGHASH_ID, (unsigned)HARDFORK_SIGHASH_ID, (unsigned)HARDFORK_SIGHASH_ID));
 
+    // fork difficulty drop factor (MVF-Core TODO: MVHF-CORE-DES-DIAD-?)
+    strUsage += HelpMessageOpt("-diffdrop=<n>", strprintf(_("Difficulty drop factor on active network (integer). Value must be between 1 (no drop) and %u. Defaults: mainnet:%u,testnet=%u,regtest=%u"), (unsigned)MAX_HARDFORK_DROPFACTOR, (unsigned)HARDFORK_DROPFACTOR_MAINNET, (unsigned)HARDFORK_DROPFACTOR_TESTNET, (unsigned)HARDFORK_DROPFACTOR_REGTEST));
     return strUsage;
 }
 
@@ -71,22 +76,30 @@ std::string ForkCmdLineHelp()
 void ForkSetup(const CChainParams& chainparams)
 {
     int minForkHeightForNetwork = 0;
+    unsigned defaultDropFactorForNetwork = 1;
     std:string activeNetworkID = chainparams.NetworkIDString();
 
     LogPrintf("%s: MVF: doing setup\n", __func__);
     LogPrintf("%s: MVF: fork consensus code = %s\n", __func__, post_fork_consensus_id);
     LogPrintf("%s: MVF: active network = %s\n", __func__, activeNetworkID);
 
-    // determine minimum fork height according to network
-    // (these are set to the same as the default fork heights for now, but could be made different)
-    if (activeNetworkID == CBaseChainParams::MAIN)
+    // determine default drop factors and minimum fork heights according to network
+    // (minimum fork heights are set to the same as the default fork heights for now, but could be made different)
+    if (activeNetworkID == CBaseChainParams::MAIN) {
         minForkHeightForNetwork = HARDFORK_HEIGHT_MAINNET;
-    else if (activeNetworkID == CBaseChainParams::TESTNET)
+        defaultDropFactorForNetwork = HARDFORK_DROPFACTOR_MAINNET;
+    }
+    else if (activeNetworkID == CBaseChainParams::TESTNET) {
         minForkHeightForNetwork = HARDFORK_HEIGHT_TESTNET;
-    else if (activeNetworkID == CBaseChainParams::REGTEST)
+        defaultDropFactorForNetwork = HARDFORK_DROPFACTOR_TESTNET;
+    }
+    else if (activeNetworkID == CBaseChainParams::REGTEST) {
         minForkHeightForNetwork = HARDFORK_HEIGHT_REGTEST;
-    else
+        defaultDropFactorForNetwork = HARDFORK_DROPFACTOR_REGTEST;
+    }
+    else {
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, activeNetworkID));
+    }
 
     FinalActivateForkHeight = GetArg("-forkheight", minForkHeightForNetwork);
 
@@ -94,6 +107,12 @@ void ForkSetup(const CChainParams& chainparams)
     if (FinalActivateForkHeight <= 0)
     {
         LogPrintf("MVF: Error: specified fork height (%d) is less than minimum for '%s' network (%d)\n", FinalActivateForkHeight, activeNetworkID, minForkHeightForNetwork);
+        StartShutdown();
+    }
+
+    FinalDifficultyDropFactor = (unsigned) GetArg("-diffdrop", defaultDropFactorForNetwork);
+    if (FinalDifficultyDropFactor < 1 || FinalDifficultyDropFactor > MAX_HARDFORK_DROPFACTOR) {
+        LogPrintf("MVF: Error: specified difficulty drop (%u) is not in range 1..%u\n", FinalDifficultyDropFactor, (unsigned)MAX_HARDFORK_DROPFACTOR);
         StartShutdown();
     }
 

--- a/src/mvf-core.h
+++ b/src/mvf-core.h
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 // MVF-Core common declarations
+
 #pragma once
 #ifndef BITCOIN_MVF_CORE_H
 #define BITCOIN_MVF_CORE_H
@@ -21,6 +22,13 @@ extern std::string autoWalletBackupSuffix;      // MVHF-CORE-DES-WABU-1
 // version string identifying the consensus-relevant algorithmic changes
 // so that a user can quickly see if fork clients are compatible
 extern std::string post_fork_consensus_id;
+
+// CAUTION! certain constant definitions from this file are parsed
+// and extracted by the Python test framework (util.py).
+// Usually there should be notes documenting where values have to
+// respect a certain format, but please tread carefully with the
+// formatting and do not just refactor the C++ names without
+// modifying the Python code.
 
 // default values that can be easily put into an enum
 enum {

--- a/src/mvf-core.h
+++ b/src/mvf-core.h
@@ -11,6 +11,7 @@
 class CChainParams;
 
 extern int FinalActivateForkHeight;             // MVHF-CORE-DES-TRIG-4
+extern unsigned FinalDifficultyDropFactor;      // MVF-Core TODO: MVHF-CORE-DES-DIAD-?
 extern bool wasMVFHardForkPreviouslyActivated;  // MVHF-CORE-DES-TRIG-5
 extern bool isMVFHardForkActive;                // MVHF-CORE-DES-TRIG-5
 extern int FinalForkId;                         // MVHF-CORE-DES-CSIG-1
@@ -27,6 +28,7 @@ enum {
 // MVF-CORE TODO: choose values with some consideration instead of dummy values
 HARDFORK_MAX_BLOCK_SIZE = 2000000,   // the fork's new maximum block size, in bytes
 // MVF-Core TODO: choose values with some consideration instead of dummy values
+// must be digit-only numerals (no operators) since they are read in by Python test framework
 HARDFORK_HEIGHT_MAINNET =  666666,   // operational network trigger height
 HARDFORK_HEIGHT_TESTNET = 9999999,   // public test network trigger height
 HARDFORK_HEIGHT_REGTEST = 9999999,   // regression test network (local)  trigger height
@@ -35,17 +37,21 @@ HARDFORK_HEIGHT_REGTEST = 9999999,   // regression test network (local)  trigger
 // period (in blocks) from fork activation until retargeting returns to normal
 HARDFORK_RETARGET_BLOCKS = 180*144,    // number of blocks during which special fork retargeting is active
 // default drop factors for various networks (MVF-Core TODO: design reference)
-HARDFORK_DROPFACTOR_MAINNET = 10000,       // default difficulty drop on operational network (mainnet)
-HARDFORK_DROPFACTOR_TESTNET = 1000,        // default difficulty drop on public test network (testnet)
-HARDFORK_DROPFACTOR_REGTEST = 4,           // default difficulty drop on local regression test network (regtestnet)
+// must be digit-only numerals  (no operators) since they are read in by Python test framework
+MAX_HARDFORK_DROPFACTOR = 1000000,     // maximum drop factor
+HARDFORK_DROPFACTOR_MAINNET = 100000,  // default difficulty drop on operational network (mainnet)
+HARDFORK_DROPFACTOR_TESTNET = 10000,   // default difficulty drop on public test network (testnet)
+HARDFORK_DROPFACTOR_REGTEST = 4,       // default difficulty drop on local regression test network (regtestnet)
 
 // MVHF-CORE-DES-NSEP-1 - network separation parameter defaults
 // MVF-Core TODO: re-check that these port values could be used
+// must be digit-only numerals (no operators) since they are read in by Python test framework
 HARDFORK_PORT_MAINNET = 9542,        // default post-fork port on operational network (mainnet)
 HARDFORK_PORT_TESTNET = 9543,        // default post-fork port on public test network (testnet)
 HARDFORK_PORT_REGTEST = 19655,       // default post-fork port on local regression test network (regtestnet)
 
 // MVHF-CORE-DES-CSIG-1 - signature change parameter defaults
+// must be hex numerals (0x prefix) since they are read in and converted from hex by Python test framework
 HARDFORK_SIGHASH_ID = 0x555000,      // 3 byte fork id that is left-shifted by 8 bits and then ORed with the SIGHASHes
 MAX_HARDFORK_SIGHASH_ID = 0xFFFFFF,  // fork id may not exceed maximum representable in 3 bytes
 };
@@ -59,7 +65,6 @@ MAX_HARDFORK_SIGHASH_ID = 0xFFFFFF,  // fork id may not exceed maximum represent
 // MVF-Core TODO: Clarify why it's ok for testnet to deviate from the above rationale.
 //              One would expect regtestnet to be less important than a public network!
 static const CMessageHeader::MessageStartChars pchMessageStart_HardForkMainnet  = { 0xf9, 0xbe, 0xb4, 0xd9 },
-                                               pchMessageStart_HardForkNolnet   = { 0xfa, 0xce, 0xc4, 0xe9 },
                                                pchMessageStart_HardForkTestnet  = { 0x0b, 0x11, 0x09, 0x07 },
                                                pchMessageStart_HardForkRegtest  = { 0xf9, 0xbe, 0xb4, 0xd9 };
 

--- a/src/mvf-core.h
+++ b/src/mvf-core.h
@@ -34,6 +34,10 @@ HARDFORK_HEIGHT_REGTEST = 9999999,   // regression test network (local)  trigger
 // MVHF-CORE-DES-DIAD-3 / MVHF-CORE-DES-DIAD-4
 // period (in blocks) from fork activation until retargeting returns to normal
 HARDFORK_RETARGET_BLOCKS = 180*144,    // number of blocks during which special fork retargeting is active
+// default drop factors for various networks (MVF-Core TODO: design reference)
+HARDFORK_DROPFACTOR_MAINNET = 10000,       // default difficulty drop on operational network (mainnet)
+HARDFORK_DROPFACTOR_TESTNET = 1000,        // default difficulty drop on public test network (testnet)
+HARDFORK_DROPFACTOR_REGTEST = 4,           // default difficulty drop on local regression test network (regtestnet)
 
 // MVHF-CORE-DES-NSEP-1 - network separation parameter defaults
 // MVF-Core TODO: re-check that these port values could be used

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -224,12 +224,11 @@ unsigned int CalculateMVFResetWorkRequired(const CBlockIndex* pindexLast, int64_
     arith_uint256 bnNew, bnNew1, bnNew2, bnOld;
 
     // TODO : Determine best reset formula
-    // drop difficulty via factor
-    int nDropFactor = 4;
+    // currently we drop difficulty by a factor (see help for -diffdrop option)
     // use same formula as standard
     int64_t nActualTimespan = pindexLast->GetBlockTime() - nFirstBlockTime;
     // used reduced target time span
-    int64_t nTargetTimespan = nActualTimespan / nDropFactor;
+    int64_t nTargetTimespan = nActualTimespan / FinalDifficultyDropFactor;
 
     bnOld.SetCompact(pindexLast->nBits);
     bnNew1 = bnOld / nTargetTimespan;

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -144,6 +144,7 @@ BOOST_AUTO_TEST_CASE(MVFCheckCalculateMVFResetWorkRequired)
     SoftSetBoolArg("-force-retarget", true);
 
     // test for drop factor x4
+    FinalDifficultyDropFactor = HARDFORK_DROPFACTOR_REGTEST;
     BOOST_CHECK_EQUAL(CalculateMVFResetWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1c168fcf);
 }
 // MVF-Core end


### PR DESCRIPTION
util.py: Extraction of regtest-relevant default definitions from C++ headers added

Fork difficulty drop has been made configurable using the -diffdrop parameter (per network).
The allowed integer range is from 1..1000000.
This parameter still needs requirement / design specification (TODOs have been added to mark missing traceability references).