### PR TITLE
merge of btcfork.conf parsing (PR58) from MVF-BU

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -75,18 +75,18 @@ private_double_opts = ('--list',
                        '--only-extended',
                        '--force-enable',
                        '--win')
-test_script_opts = ('--tracerpc',
-                    '--help',
-                    '--noshutdown',
-                    '--nocleanup',
-                    '--srcdir',
-                    '--tmpdir',
-                    '--coveragedir',
-                    '--quick',
-                    '--randomseed',
-                    '--mineblock',
-                    '--testbinary',
-                    '--refbinary')
+framework_opts = ('--tracerpc',
+                  '--help',
+                  '--noshutdown',
+                  '--nocleanup',
+                  '--srcdir',
+                  '--tmpdir',
+                  '--coveragedir',
+                  '--randomseed',
+                  '--testbinary',
+                  '--refbinary')
+test_script_opts = ('--mineblock',
+                    '--quick')
 
 def option_passed(option_without_dashes):
     """check if option was specified in single-dash or double-dash format"""
@@ -120,7 +120,7 @@ bad_opts_found = []
 bad_opt_str="Unrecognized option: %s"
 for o in opts | double_opts:
     if o.startswith('--'):
-        if o not in test_script_opts + private_double_opts:
+        if o not in framework_opts + test_script_opts + private_double_opts:
             print bad_opt_str % o
             bad_opts_found.append(o)
     elif o.startswith('-'):
@@ -281,17 +281,23 @@ def runtests():
                             if all_args_found:
                                 tests_to_run.append(t)
                                 found = True
-                        elif str(t) == o or str(t) == o + '.py':
-                            # it is a test without args - just add it or only add it if no passed on args?
-                            if not passOn:
+                        elif t_rep[0] == o or t_rep[0] == o + '.py':
+                            passOnSplit = [x for x in passOn.split(' ') if x != '']
+                            found_non_framework_opt = False
+                            for p in passOnSplit:
+                                if p in test_script_opts:
+                                    found_non_framework_opt = True
+                            if not found_non_framework_opt:
                                 tests_to_run.append(t)
                                 found = True
                     if not found:
                         print "Error: %s is not a known test." % o
                         sys.exit(1)
 
-        #print "tests after explicit collection:"
-        #print tests_to_run
+        #if len(tests_to_run):
+        #    print "tests explicitly specified:"
+        #    for t in tests_to_run:
+        #        print t
 
         # if no explicit tests specified, use the lists
         if not len(tests_to_run):

--- a/qa/rpc-tests/mvf-core-trig.py
+++ b/qa/rpc-tests/mvf-core-trig.py
@@ -27,7 +27,7 @@ class MVF_TRIG_Test(BitcoinTestFramework):
         self.btcfork_conf = {}
         for n in range(0,4):
             self.nodelog[n] = os.path.join(self.options.tmpdir,"node%d" % n,"regtest","debug.log")
-            self.btcfork_conf[n] = os.path.join(self.options.tmpdir,"node%d" % n,"regtest","btcfork.conf")
+            self.btcfork_conf[n] = os.path.join(self.options.tmpdir,"node%d" % n,"regtest",BTCFORK_CONF_FILENAME)
 
     def start_all_nodes(self):
         self.nodes = []

--- a/qa/rpc-tests/mvf-core-trig.py
+++ b/qa/rpc-tests/mvf-core-trig.py
@@ -23,10 +23,16 @@ class MVF_TRIG_Test(BitcoinTestFramework):
     def setup_chain(self):
         print("Initializing test directory " + self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 4)
+        self.nodelog = {}
+        self.btcfork_conf = {}
+        for n in range(0,4):
+            self.nodelog[n] = os.path.join(self.options.tmpdir,"node%d" % n,"regtest","debug.log")
+            self.btcfork_conf[n] = os.path.join(self.options.tmpdir,"node%d" % n,"regtest","btcfork.conf")
 
     def start_all_nodes(self):
         self.nodes = []
         self.is_network_split = False
+        self.expected_fork_entries = {}
         self.nodes.append(start_node(0, self.options.tmpdir,
                             ["-forkheight=100", ]))
         self.nodes.append(start_node(1, self.options.tmpdir,
@@ -37,23 +43,50 @@ class MVF_TRIG_Test(BitcoinTestFramework):
         self.nodes.append(start_node(3, self.options.tmpdir,
                             ["-forkheight=300",
                              "-blockversion=%s" % 0x20000002])) # signal SegWit, but forkheight should pre-empt
+        self.expected_fork_entries[0] = { "forkheight": "100", "forkid": "5591040", "autobackupblock": "99"}
+        self.expected_fork_entries[1] = { "forkheight": "200", "forkid": "5591040", "autobackupblock": "199"}
+        self.expected_fork_entries[2] = { "forkheight": "431", "forkid": "5591040", "autobackupblock": "431"}
+        self.expected_fork_entries[3] = { "forkheight": "300", "forkid": "5591040", "autobackupblock": "299"}
 
     def setup_network(self):
         self.start_all_nodes()
 
     def prior_fork_detected_on_node(self, node=0):
         """ check in log file if prior fork has been detected and return true/false """
-        nodelog = self.options.tmpdir + "/node%s/regtest/debug.log" % node
-        marker_found = search_file(nodelog, "MVF: found marker config file")
+        marker_found = search_file(self.nodelog[node], "MVF: found marker config file")
         return (len(marker_found) > 0)
+
+    def is_config_file_consistent(self, node=0, entry_map={}):
+        """ check whether btcfork.conf file matches expectations,
+        and return true/false. One of the assumptions is that the
+        config file should exist. Do not call this function otherwise."""
+        config_file_written = search_file(self.nodelog[node], "MVF: writing")
+        if len(config_file_written) == 0:
+            # absence of config file is unexpected
+            print "is_config_file_consistent: config file not found for node %d" % node
+            return False
+        verify_btcfork_conf = config_file_written[0].split(" ")[-1:][0].strip()
+        if verify_btcfork_conf != self.btcfork_conf[node]:
+            # check that filename matches what is expected
+            print "is_config_file_consistent: config filename %s mismatch %s for node %d" % (verify_btcfork_conf, self.btcfork_conf[node], node)
+            return False
+        for key in entry_map.keys():
+            key_found = search_file(self.btcfork_conf[node], "%s=" % key)
+            if (len(key_found) != 1):
+                print "is_config_file_consistent: key %s not found for node %d" % (key, node)
+                return False
+            val_found=key_found[0].split("=")[1].strip()
+            if (val_found != entry_map[key]):
+                print "is_config_file_consistent: unexpected value '%s' for key %s found for node %d" % (val_found, key, node)
+                return False
+        return True
 
     def is_fork_triggered_on_node(self, node=0):
         """ check in log file if fork has triggered and return true/false """
         # MVF-Core TODO: extend to check using RPC info about forks
-        nodelog = self.options.tmpdir + "/node%s/regtest/debug.log" % node
-        hf_active = (search_file(nodelog, "isMVFHardForkActive=1") and
-                     search_file(nodelog, "enabling isMVFHardForkActive"))
-        fork_actions_performed = search_file(nodelog, "MVF: performing fork activation actions")
+        hf_active = (search_file(self.nodelog[node], "isMVFHardForkActive=1") and
+                     search_file(self.nodelog[node], "enabling isMVFHardForkActive"))
+        fork_actions_performed = search_file(self.nodelog[node], "MVF: performing fork activation actions")
         return (len(hf_active) > 0 and len(fork_actions_performed) == 1)
 
     def run_test(self):
@@ -70,15 +103,12 @@ class MVF_TRIG_Test(BitcoinTestFramework):
         for n in xrange(len(self.nodes)):
             self.nodes[n].generate(1)
         assert_equal(True,  self.is_fork_triggered_on_node(0))
+        assert_equal(True,  self.is_config_file_consistent(0, self.expected_fork_entries[0]))
         assert_equal(False, self.prior_fork_detected_on_node(0))
         for n in [1,2,3]:
             assert_equal(False, self.is_fork_triggered_on_node(n))
             assert_equal(False, self.prior_fork_detected_on_node(n))
 
-        assert_equal(True,   self.is_fork_triggered_on_node(0))
-        assert_equal(False,  self.is_fork_triggered_on_node(1))
-        assert_equal(False,  self.is_fork_triggered_on_node(2))
-        assert_equal(False,  self.is_fork_triggered_on_node(3))
         print "Fork triggered successfully on node 0 (block height 100)"
 
         # check node 1 triggering around height 200
@@ -86,6 +116,7 @@ class MVF_TRIG_Test(BitcoinTestFramework):
         assert_equal(False, self.is_fork_triggered_on_node(1))
         self.nodes[1].generate(1)
         assert_equal(True,  self.is_fork_triggered_on_node(1))
+        assert_equal(True,  self.is_config_file_consistent(1, self.expected_fork_entries[1]))
         print "Fork triggered successfully on node 1 (block height 200)"
 
         # check node 2 triggering around height 431
@@ -95,6 +126,7 @@ class MVF_TRIG_Test(BitcoinTestFramework):
                             or self.prior_fork_detected_on_node(2))
         self.nodes[2].generate(1)
         assert_equal(True,  self.is_fork_triggered_on_node(2))
+        assert_equal(True,  self.is_config_file_consistent(2, self.expected_fork_entries[2]))
         assert_equal(False, self.prior_fork_detected_on_node(2))
         # block 431 is when fork activation is performed.
         # block 432 is first block where new consensus rules are in effect.
@@ -107,6 +139,7 @@ class MVF_TRIG_Test(BitcoinTestFramework):
                             or self.prior_fork_detected_on_node(3))
         self.nodes[3].generate(1)
         assert_equal(True,  self.is_fork_triggered_on_node(3))
+        assert_equal(True,  self.is_config_file_consistent(3, self.expected_fork_entries[3]))
         assert_equal(False, self.prior_fork_detected_on_node(3))
         print "Fork triggered successfully on node 3 (block height 300 ahead of SegWit)"
 
@@ -124,8 +157,8 @@ class MVF_TRIG_Test(BitcoinTestFramework):
         self.start_all_nodes()
         for n in xrange(4):
             assert_equal(True, self.prior_fork_detected_on_node(n))
-            nodelog=os.path.join(self.options.tmpdir,"node%d" % n,"regtest","debug.log")
-            assert(len(search_file(nodelog, "enabling isMVFHardForkActive")) == 1)
+            assert(len(search_file(self.nodelog[n], "enabling isMVFHardForkActive")) == 1)
+            assert(len(search_file(self.nodelog[n], "found marker config file")) == 1)
         print "Prior fork activation detected on all nodes"
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/walletbackupauto.py
+++ b/qa/rpc-tests/walletbackupauto.py
@@ -7,15 +7,18 @@
 """
 See https://github.com/BTCfork/hardfork_prototype_1_mvf-core/blob/master/doc/mvf-core-test-design.md#411
 
-
 Exercise the auto backup wallet code.  Ported from walletbackup.sh.
 
 Test case is:
-5 nodes. 1 2 and 3 send transactions between each other, fourth node is a miner.
+6 nodes: node0..node5 .
+Nodes 1 2 and 3 send transactions between each other, fourth node is a miner.
 The 5th node does no transactions and only tests for the -disablewallet conflict.
-.
-1 2 3 each mine a block to start, then
-Miner creates 100 blocks so 1 2 3 each have 50 mature coins to spend.
+The 6th node is stopped at pre-fork block and restarted post-fork to check
+that it does not perform another backup since it already has performed one
+at the pre-fork block.
+
+Nodes 1 2 3 each mine a block to start, then miner (node 4) creates
+100 blocks so 1 2 3 each have 50 mature coins to spend.
 Then 5 iterations of 1/2/3 sending coins amongst
 themselves to get transactions in the wallets,
 and the miner mining one block.
@@ -28,11 +31,16 @@ as defined in the backupblock constant 114.
 Balances are saved for sanity check:
   Sum(1,2,3,4 balances) == 114*50
 
-1/2/3/4 are shutdown, and their wallets erased.
-Then restored using the auto backup wallets eg wallet.dat.auto.114.bak.
-Sanity check to confirm 1/2/3/4 balances match the 114 block balances.
+Node5 is stopped after its backup block (right before the fork activation
+block). It is only restarted after the fork block.
+
+1/2/3/4 are shutdown after the fork. Their wallets are erased and then
+restored using the auto backup wallets eg wallet.dat.auto.114.bak.
+Sanity check to confirm 1/2/3/4 balances match the pre-fork block 114 balances.
 Sanity check to confirm 5th node does NOT perform the auto backup
 and that the debug.log contains a conflict message
+Sanity check to confirm 6th node does NOT perform another backup at fork
+block after it has already performed a backup at pre-fork block.
 
 Node 2 is rewinded to before the backup height, and a check is made that
 an existing backup is copied to a .old file with identical contents if the
@@ -59,7 +67,7 @@ class WalletBackupTest(BitcoinTestFramework):
 
     def setup_chain(self):
         logging.info("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 5)
+        initialize_chain_clean(self.options.tmpdir, 6)
 
     # This mirrors how the network was setup in the bash test
     def setup_network(self, split=False):
@@ -87,13 +95,15 @@ class WalletBackupTest(BitcoinTestFramework):
             ["-disablewallet",
                 "-autobackupwalletpath="+ os.path.join(self.options.tmpdir,"node4"),
                 "-forkheight=%s"%(backupblock+1),
-                "-autobackupblock=%s"%(backupblock)]]
+                "-autobackupblock=%s"%(backupblock)],
+            ["-autobackupblock=%s"%(backupblock),
+                "-forkheight=%s"%(backupblock+1)],
+            ]
 
-        self.nodes = start_nodes(5, self.options.tmpdir, self.extra_args)
-        connect_nodes(self.nodes[0], 3)
-        connect_nodes(self.nodes[1], 3)
-        connect_nodes(self.nodes[2], 3)
-        connect_nodes(self.nodes[4], 3)
+        self.nodes = start_nodes(6, self.options.tmpdir, self.extra_args)
+        # set up a star topology with everyone connected to miner
+        for ni in range(6):
+            if ni != 3: connect_nodes_bi(self.nodes, ni, 3)
         self.is_network_split=False
         self.sync_all()
 
@@ -124,16 +134,12 @@ class WalletBackupTest(BitcoinTestFramework):
         for i in range(4):
             self.nodes[i] = start_node(i, self.options.tmpdir, self.extra_args[i])
 
-        connect_nodes(self.nodes[0], 3)
-        connect_nodes(self.nodes[1], 3)
-        connect_nodes(self.nodes[2], 3)
-
+        for ni in range(6):
+            if ni != 3: connect_nodes_bi(self.nodes, ni, 3)
 
     def stop_four(self):
-        stop_node(self.nodes[0], 0)
-        stop_node(self.nodes[1], 1)
-        stop_node(self.nodes[2], 2)
-        stop_node(self.nodes[3], 3)
+        for i in range(4):
+            stop_node(self.nodes[i], i)
 
     def erase_hot_wallets(self):
         for node in xrange(4):
@@ -144,18 +150,21 @@ class WalletBackupTest(BitcoinTestFramework):
         assert_greater_than(backupblock, 113)
 
         # target backup files
-        node0backupfile = os.path.join(self.options.tmpdir,"node0","newabsdir","pathandfile.%s.bak"%(backupblock))
-        node1backupfile = os.path.join(self.options.tmpdir,"node1","regtest","filenameonly.%s.bak"%(backupblock))
-        node2backupfile = os.path.join(self.options.tmpdir,"node2","regtest","newreldir","wallet.dat.auto.%s.bak"%(backupblock))
-        node3backupfile = os.path.join(self.options.tmpdir,"node3","regtest","wallet.dat.auto.%s.bak"%(backupblock))
+        nodebackupfile = [ os.path.join(self.options.tmpdir,"node0","newabsdir","pathandfile.%s.bak"%(backupblock)),
+                           os.path.join(self.options.tmpdir,"node1","regtest","filenameonly.%s.bak"%(backupblock)),
+                           os.path.join(self.options.tmpdir,"node2","regtest","newreldir","wallet.dat.auto.%s.bak"%(backupblock)),
+                           os.path.join(self.options.tmpdir,"node3","regtest","wallet.dat.auto.%s.bak"%(backupblock)),
+                           os.path.join(self.options.tmpdir,"node4","regtest","wallet.dat.auto.%s.bak"%(backupblock)),
+                           os.path.join(self.options.tmpdir,"node5","regtest","wallet.dat.auto.%s.bak"%(backupblock)),
+                         ]
+
+        # we want to check later on that this duplicate is not generated
+        node5duplicate_path = os.path.join(self.options.tmpdir,"node5","regtest","wallet.dat.auto.%s.bak"%(backupblock+1))
 
         logging.info("Generating initial blockchain")
-        self.nodes[0].generate(1)
-        sync_blocks(self.nodes)
-        self.nodes[1].generate(1)
-        sync_blocks(self.nodes)
-        self.nodes[2].generate(1)
-        sync_blocks(self.nodes)
+        for ni in range(3):
+            self.nodes[ni].generate(1)
+            sync_blocks(self.nodes)
         self.nodes[3].generate(100)
 
         sync_blocks(self.nodes)
@@ -191,31 +200,15 @@ class WalletBackupTest(BitcoinTestFramework):
 
         # Only 1 more block until the auto backup is triggered
         # Test the auto backup files do NOT exist yet
-        node0backupexists = 0
-        node1backupexists = 0
-        node2backupexists = 0
-        node3backupexists = 0
+        nodebackupexists = [0,0,0,0,0,0]
 
-        if os.path.isfile(node0backupfile):
-            node0backupexists = 1
-            logging.info("Error backup exists too early: %s"%(node0backupfile))
+        for ci in [0,1,2,3,5]:
+            if os.path.isfile(nodebackupfile[ci]):
+                nodebackupexists[ci] = 1
+                logging.info("Error backup exists too early: %s"%(nodebackupfile[ci]))
 
-        if os.path.isfile(node1backupfile):
-            node1backupexists = 1
-            logging.info("Error backup exists too early: %s"%(node1backupfile))
-
-        if os.path.isfile(node2backupfile):
-            node2backupexists = 1
-            logging.info("Error backup exists too early: %s"%(node2backupfile))
-
-        if os.path.isfile(node3backupfile):
-            node3backupexists = 1
-            logging.info("Error backup exists too early: %s"%(node3backupfile))
-
-        assert_equal(0, node0backupexists)
-        assert_equal(0, node1backupexists)
-        assert_equal(0, node2backupexists)
-        assert_equal(0, node3backupexists)
+        for ci in [0,1,2,3,5]:
+            assert_equal(0, nodebackupexists[ci])
 
         # Generate the block that should trigger the auto backup
         self.nodes[3].generate(1)
@@ -224,48 +217,50 @@ class WalletBackupTest(BitcoinTestFramework):
 
         logging.info("Reached backup block %s automatic backup triggered"%(self.nodes[0].getblockcount()))
 
+        logging.info("Stopping node 5 (to check backup is not made twice if we restart at fork)")
+        stop_node(self.nodes[5], 5)
+
         # Test if the backup files exist
-        if os.path.isfile(node0backupfile): node0backupexists = 1
-        else: logging.info("Error backup does not exist: %s"%(node0backupfile))
+        for ci in [0,1,3]:
+            if os.path.isfile(nodebackupfile[ci]):
+                nodebackupexists[ci] = 1
+            else:
+                logging.info("Error backup does not exist: %s"%(nodebackupfile[0]))
 
-        if os.path.isfile(node1backupfile): node1backupexists = 1
-        else: logging.info("Error backup does not exist: %s"%(node1backupfile))
-
-        if os.path.isfile(node2backupfile):
-            node2backupexists = 1
+        if os.path.isfile(nodebackupfile[2]):
+            nodebackupexists[2] = 1
             # take MD5 for comparison to .old file in later test
-            node2backupfile_orig_md5 = hashlib.md5(open(node2backupfile, 'rb').read()).hexdigest()
-        else: logging.info("Error backup does not exist: %s"%(node2backupfile))
+            node2backupfile_orig_md5 = hashlib.md5(open(nodebackupfile[2], 'rb').read()).hexdigest()
+        else: logging.info("Error backup does not exist: %s"%(nodebackupfile[2]))
 
-        if os.path.isfile(node3backupfile): node3backupexists = 1
-        else: logging.info("Error backup does not exist: %s"%(node3backupfile))
-
-        assert_equal(1, node0backupexists)
-        assert_equal(1, node1backupexists)
-        assert_equal(1, node2backupexists)
-        assert_equal(1, node3backupexists)
+        for ci in range(4):
+            assert_equal(1, nodebackupexists[ci])
 
         # generate one more block to trigger the fork
         self.nodes[3].generate(1)
-        self.sync_all()
+        sync_blocks(self.nodes[:-1])
         assert_equal(self.nodes[0].getblockcount(),backupblock+1)
+
+        logging.info("Restarting node 5 to check absence of soft-fork backup at fork")
+        self.nodes[5] = start_node(5, self.options.tmpdir,["-forkheight=%s"%(backupblock+1),
+                                                           "-autobackupblock=%s"%(backupblock) ])
+        connect_nodes_bi(self.nodes, 5, 3)
+        self.sync_all()
+        sync_blocks(self.nodes[:-1])
+        # check that restarting the node has NOT created another backup at the fork block height
+        assert(not os.path.exists(node5duplicate_path))
 
         ##
         # Calculate wallet balances for comparison after restore
         ##
 
+        total = 0
+        balance = [0,0,0,0]
         # Balance of each wallet
-        balance0 = self.nodes[0].getbalance()
-        balance1 = self.nodes[1].getbalance()
-        balance2 = self.nodes[2].getbalance()
-        balance3 = self.nodes[3].getbalance()
-
-        total = balance0 + balance1 + balance2 + balance3
-
-        logging.info("Node0 balance:" + str(balance0))
-        logging.info("Node1 balance:" + str(balance1))
-        logging.info("Node2 balance:" + str(balance2))
-        logging.info("Node3 balance:" + str(balance3))
+        for nb in range(4):
+            balance[nb] = self.nodes[nb].getbalance()
+            logging.info("Node%d balance: %s" % (nb, str(balance[nb])))
+            total += balance[nb]
 
         logging.info("Original Wallet Total: " + str(total))
 
@@ -277,42 +272,36 @@ class WalletBackupTest(BitcoinTestFramework):
         self.erase_hot_wallets()
 
         # Restore wallets from backup
-        shutil.copyfile(node0backupfile, os.path.join(tmpdir,"node0","regtest","wallet.dat"))
-        shutil.copyfile(node1backupfile, os.path.join(tmpdir,"node1","regtest","wallet.dat"))
-        shutil.copyfile(node2backupfile, os.path.join(tmpdir,"node2","regtest","wallet.dat"))
-        shutil.copyfile(node3backupfile, os.path.join(tmpdir,"node3","regtest","wallet.dat"))
+        for ci in range(4):
+            shutil.copyfile(nodebackupfile[ci], os.path.join(tmpdir,"node%d"%ci,"regtest","wallet.dat"))
 
         logging.info("Re-starting nodes")
         self.start_four()
         self.sync_all()
 
         total2 = self.nodes[0].getbalance() + self.nodes[1].getbalance() + self.nodes[2].getbalance() + self.nodes[3].getbalance()
-        logging.info("Node0 balance:" + str(self.nodes[0].getbalance()))
-        logging.info("Node1 balance:" + str(self.nodes[1].getbalance()))
-        logging.info("Node2 balance:" + str(self.nodes[2].getbalance()))
-        logging.info("Node3.balance:" + str(self.nodes[3].getbalance()))
+        for ci in range(4):
+            logging.info("Node%d balance: %s" % (ci, str(self.nodes[ci].getbalance())))
 
         logging.info("Backup Wallet Total: " + str(total2))
 
         # balances should equal the auto backup balances
-        assert_equal(self.nodes[0].getbalance(), balance0)
-        assert_equal(self.nodes[1].getbalance(), balance1)
-        assert_equal(self.nodes[2].getbalance(), balance2)
-        assert_equal(self.nodes[3].getbalance(), balance3)
+        for ci in range(4):
+            assert_equal(self.nodes[ci].getbalance(), balance[ci])
         assert_equal(total,total2)
 
         # Test Node4 auto backup wallet does NOT exist: tmpdir + "/node4/wallet.dat.auto.114.bak"
         # when -disablewallet is enabled then no backup file should be created and graceful exit happens
         # without causing a runtime error
-        node4backupexists = 0
+        nodebackupexists[4] = 0
         if os.path.isfile(os.path.join(tmpdir,"node4","regtest","wallet.dat.auto.%s.bak"%(backupblock))):
-            node4backupexists = 1
+            nodebackupexists[4] = 1
             logging.info("Error: Auto backup performed on node4 with -disablewallet!")
 
         # Test Node4 debug.log contains a conflict message - length test should be > 0
         debugmsg_list = search_file(os.path.join(tmpdir,"node4","regtest","debug.log"),"-disablewallet and -autobackupwalletpath conflict")
 
-        assert_equal(0,node4backupexists)
+        assert_equal(0,nodebackupexists[4])
         assert_greater_than(len(debugmsg_list),0)
 
         # test that existing wallet backup is preserved
@@ -320,7 +309,7 @@ class WalletBackupTest(BitcoinTestFramework):
         logging.info("Stopping all nodes")
         self.stop_four()
         for n in xrange(4):
-            os.unlink(os.path.join(tmpdir,"node%s" % n,BTCFORK_CONF_FILENAME))
+            os.unlink(os.path.join(tmpdir,"node%s" % n,"regtest",BTCFORK_CONF_FILENAME))
         logging.info("Erasing blockchain on node 2 while keeping backup file")
         shutil.rmtree(self.options.tmpdir + "/node2/regtest/blocks")
         shutil.rmtree(self.options.tmpdir + "/node2/regtest/chainstate")
@@ -352,7 +341,7 @@ class WalletBackupTest(BitcoinTestFramework):
         self.nodes[2].generate(backupblock+1)
         logging.info("Checksum ok - shutting down")
         stop_node(self.nodes[2], 2)
-        os.unlink(os.path.join(tmpdir,"node2",BTCFORK_CONF_FILENAME))
+        os.unlink(os.path.join(tmpdir,"node2","regtest",BTCFORK_CONF_FILENAME))
         self.start_four()
 
         # test that wallet backup is not performed again if fork has already
@@ -360,13 +349,13 @@ class WalletBackupTest(BitcoinTestFramework):
         # (otherwise it would backup a later-state wallet)
         logging.info("stopping node 1")
         stop_node(self.nodes[1], 1)
-        logging.info("checking that wallet backup file exists: %s" % node1backupfile)
-        assert(os.path.isfile(node1backupfile))
-        logging.info("removing wallet backup file %s" % node1backupfile)
-        os.remove(node1backupfile)
+        logging.info("checking that wallet backup file exists: %s" % nodebackupfile[1])
+        assert(os.path.isfile(nodebackupfile[1]))
+        logging.info("removing wallet backup file %s" % nodebackupfile[1])
+        os.remove(nodebackupfile[1])
         # check that no wallet backup file created
         logging.info("restarting node 1")
-        os.unlink(os.path.join(tmpdir,"node1",BTCFORK_CONF_FILENAME))
+        os.unlink(os.path.join(tmpdir,"node1","regtest",BTCFORK_CONF_FILENAME))
         self.nodes[1] = start_node(1, self.options.tmpdir, ["-keypool=100",
                                                             "-autobackupwalletpath=filenameonly.@.bak",
                                                             "-forkheight=%s"%(backupblock+1),
@@ -374,11 +363,11 @@ class WalletBackupTest(BitcoinTestFramework):
         logging.info("generating another block on node 1")
         self.nodes[1].generate(1)
         logging.info("checking that backup file has not been created again...")
-        node1backupexists = 0
-        if os.path.isfile(node1backupfile):
-            node1backupexists = 1
+        nodebackupexists[1] = 0
+        if os.path.isfile(nodebackupfile[1]):
+            nodebackupexists[1] = 1
             logging.info("Error: Auto backup created again on node1 after fork has already activated!")
-        assert_equal(0, node1backupexists)
+        assert_equal(0, nodebackupexists[1])
 
 
 if __name__ == '__main__':

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -118,6 +118,7 @@ BITCOIN_CORE_H = \
   merkleblock.h \
   miner.h \
   mvf-core.h \
+  mvf-btcfork_conf_parser.h \
   net.h \
   netbase.h \
   noui.h \
@@ -199,6 +200,7 @@ libbitcoin_server_a_SOURCES = \
   merkleblock.cpp \
   miner.cpp \
   mvf-core.cpp \
+  mvf-btcfork_conf_parser.cpp \
   net.cpp \
   noui.cpp \
   policy/fees.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -60,6 +60,7 @@ BITCOIN_TESTS =\
   test/merkle_tests.cpp \
   test/miner_tests.cpp \
   test/multisig_tests.cpp \
+  test/mvfstandalone_tests.cpp \
   test/netbase_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \

--- a/src/mvf-btcfork_conf_parser.cpp
+++ b/src/mvf-btcfork_conf_parser.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2016 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// MVF-Core config file parsing functions
+
+#include <boost/filesystem/fstream.hpp>
+#include <boost/program_options/detail/config_file.hpp>
+
+#include "mvf-core.h"
+#include "mvf-btcfork_conf_parser.h"
+
+/* not sure if we need the following for Clang compatibility (copied this from util.cpp just in case)
+namespace boost {
+
+namespace program_options {
+std::string to_internal(const std::string&);
+}
+
+} // namespace boost
+*/
+
+using namespace std;
+
+// copied from util.cpp:ReadConfigFile with minor simplifications.
+// MVF-Core TOOD: would be good to refactor so we don't need separate procedures
+void MVFReadConfigFile(boost::filesystem::path pathCfgFile,
+                       map<string, string>& mapSettingsRet,
+                       map<string, vector<string> >& mapMultiSettingsRet)
+{
+    boost::filesystem::ifstream streamConfig(pathCfgFile);
+    if (!streamConfig.good())
+        return; // No btcfork.conf file is OK
+
+    set<string> setOptions;
+    setOptions.insert("*");
+
+    for (boost::program_options::detail::config_file_iterator it(streamConfig, setOptions), end; it != end; ++it)
+    {
+        // Don't overwrite existing settings so command line settings override bitcoin.conf
+        string strKey = string("-") + it->string_key;
+        string strValue = it->value[0];
+        if (mapSettingsRet.count(strKey) == 0)
+            mapSettingsRet[strKey] = strValue;
+        mapMultiSettingsRet[strKey].push_back(strValue);
+    }
+}

--- a/src/mvf-btcfork_conf_parser.h
+++ b/src/mvf-btcfork_conf_parser.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2016 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// MVF-Core btcfork.conf file parsing declarations
+
+#pragma once
+#ifndef BITCOIN_MVF_BTCFORK_CONF_PARSER_H
+#define BITCOIN_MVF_BTCFORK_CONF_PARSER_H
+
+#include <boost/filesystem.hpp>
+
+#include "mvf-core.h"
+
+// read btcfork.conf file
+extern void MVFReadConfigFile(boost::filesystem::path pathCfgFile, std::map<std::string, std::string>& mapSettingsRet, std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet);
+
+#endif
+

--- a/src/mvf-core.cpp
+++ b/src/mvf-core.cpp
@@ -4,16 +4,24 @@
 // MVF-Core common objects and functions
 
 #include "mvf-core.h"
+#include "mvf-btcfork_conf_parser.h"
 #include "init.h"
 #include "util.h"
+#include "utilstrencodings.h"   // for atoi64
 #include "chainparams.h"
 #include "validationinterface.h"
 
 #include <iostream>
 #include <fstream>
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/exception/to_string_stub.hpp>
 
 using namespace std;
+
+// key-value maps for btcfork.conf configuration items
+map<string, string> btcforkMapArgs;
+map<string, vector<string> > btcforkMapMultiArgs;
 
 // version string identifying the consensus-relevant algorithmic changes
 // so that a user can quickly see if MVF fork clients are compatible
@@ -80,8 +88,9 @@ void ForkSetup(const CChainParams& chainparams)
     std:string activeNetworkID = chainparams.NetworkIDString();
 
     LogPrintf("%s: MVF: doing setup\n", __func__);
-    LogPrintf("%s: MVF: fork consensus code = %s\n", __func__, post_fork_consensus_id);
-    LogPrintf("%s: MVF: active network = %s\n", __func__, activeNetworkID);
+
+    // first, set initial values from built-in defaults
+    FinalForkId = GetArg("-forkid", HARDFORK_SIGHASH_ID);
 
     // determine default drop factors and minimum fork heights according to network
     // (minimum fork heights are set to the same as the default fork heights for now, but could be made different)
@@ -102,6 +111,39 @@ void ForkSetup(const CChainParams& chainparams)
     }
 
     FinalActivateForkHeight = GetArg("-forkheight", minForkHeightForNetwork);
+    FinalDifficultyDropFactor = (unsigned) GetArg("-diffdrop", defaultDropFactorForNetwork);
+
+    // check if btcfork.conf exists (MVHF-CORE-DES-TRIG-10)
+    boost::filesystem::path pathBTCforkConfigFile(MVFGetConfigFile());
+    if (boost::filesystem::exists(pathBTCforkConfigFile)) {
+        LogPrintf("%s: MVF: found marker config file at %s - client has already forked before\n", __func__, pathBTCforkConfigFile.string().c_str());
+        // read the btcfork.conf file if it exists, override standard config values using its configuration
+        try
+        {
+            MVFReadConfigFile(pathBTCforkConfigFile, btcforkMapArgs, btcforkMapMultiArgs);
+            if (btcforkMapArgs.count("-forkheight")) {
+                FinalActivateForkHeight = atoi(btcforkMapArgs["-forkheight"]);
+                mapArgs["-forkheight"] = FinalActivateForkHeight;
+            }
+            if (btcforkMapArgs.count("-autobackupblock")) {
+                mapArgs["-autobackupblock"] = btcforkMapArgs["-autobackupblock"];
+            }
+            if (btcforkMapArgs.count("-forkid")) {
+                FinalForkId = atoi(btcforkMapArgs["-forkid"]);
+                mapArgs["-forkid"] = btcforkMapArgs["-forkid"];
+            }
+        } catch (const std::exception& e) {
+            LogPrintf("MVF: Error reading %s configuration file: %s\n", BTCFORK_CONF_FILENAME, e.what());
+            fprintf(stderr,"MVF: Error reading %s configuration file: %s\n", BTCFORK_CONF_FILENAME, e.what());
+        }
+        wasMVFHardForkPreviouslyActivated = true;
+    }
+    else {
+        LogPrintf("%s: MVF: no marker config file at %s - client has not forked yet\n", __func__, pathBTCforkConfigFile.string().c_str());
+        wasMVFHardForkPreviouslyActivated = false;
+    }
+
+    // validation
 
     // shut down immediately if specified fork height is invalid
     if (FinalActivateForkHeight <= 0)
@@ -110,13 +152,11 @@ void ForkSetup(const CChainParams& chainparams)
         StartShutdown();
     }
 
-    FinalDifficultyDropFactor = (unsigned) GetArg("-diffdrop", defaultDropFactorForNetwork);
     if (FinalDifficultyDropFactor < 1 || FinalDifficultyDropFactor > MAX_HARDFORK_DROPFACTOR) {
         LogPrintf("MVF: Error: specified difficulty drop (%u) is not in range 1..%u\n", FinalDifficultyDropFactor, (unsigned)MAX_HARDFORK_DROPFACTOR);
         StartShutdown();
     }
 
-    FinalForkId = GetArg("-forkid", HARDFORK_SIGHASH_ID);
     // check fork id for validity (MVHF-CORE-DES-CSIG-2)
     if (FinalForkId == 0) {
         LogPrintf("MVF: Warning: fork id = 0 will result in vulnerability to replay attacks\n");
@@ -128,39 +168,34 @@ void ForkSetup(const CChainParams& chainparams)
         }
     }
 
+    // debug traces of final values
+    LogPrintf("%s: MVF: fork consensus code = %s\n", __func__, post_fork_consensus_id);
+    LogPrintf("%s: MVF: active network = %s\n", __func__, activeNetworkID);
+    LogPrintf("%s: MVF: active fork id = 0x%06x (%d)\n", __func__, FinalForkId, FinalForkId);
+    LogPrintf("%s: MVF: active fork height = %d\n", __func__, FinalActivateForkHeight);
     if (GetBoolArg("-segwitfork", DEFAULT_TRIGGER_ON_SEGWIT))
         LogPrintf("%s: MVF: Segregated Witness trigger is ENABLED\n", __func__);
     else
         LogPrintf("%s: MVF: Segregated Witness trigger is DISABLED\n", __func__);
-
-    LogPrintf("%s: MVF: active fork height = %d\n", __func__, FinalActivateForkHeight);
-
-    LogPrintf("%s: MVF: active fork id = 0x%06x (%d)\n", __func__, FinalForkId, FinalForkId);
+    LogPrintf("%s: MVF: auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalActivateForkHeight - 1));
 
     if (GetBoolArg("-force-retarget", DEFAULT_FORCE_RETARGET))
         LogPrintf("%s: MVF: force-retarget is ENABLED\n", __func__);
     else
         LogPrintf("%s: MVF: force-retarget is DISABLED\n", __func__);
 
-    LogPrintf("%s: MVF: auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalActivateForkHeight - 1));
-
-    // check if btcfork.conf exists (MVHF-CORE-DES-TRIG-10)
-    boost::filesystem::path pathBTCforkConfigFile(BTCFORK_CONF_FILENAME);
-    if (!pathBTCforkConfigFile.is_complete())
-        pathBTCforkConfigFile = GetDataDir(false) / pathBTCforkConfigFile;
-    if (boost::filesystem::exists(pathBTCforkConfigFile)) {
-        LogPrintf("%s: MVF: found marker config file at %s - client has already forked before\n", __func__, pathBTCforkConfigFile.string().c_str());
-        wasMVFHardForkPreviouslyActivated = true;
-    }
-    else {
-        LogPrintf("%s: MVF: no marker config file at %s - client has not forked yet\n", __func__, pathBTCforkConfigFile.string().c_str());
-        wasMVFHardForkPreviouslyActivated = false;
-    }
-
     // we should always set the activation flag to false during setup
     isMVFHardForkActive = false;
 }
 
+/** Return full path to btcfork.conf (MVHF-BU-DES-?-?) */
+// MVF-Core TODO: traceability
+boost::filesystem::path MVFGetConfigFile()
+{
+    boost::filesystem::path pathConfigFile(BTCFORK_CONF_FILENAME);
+    pathConfigFile = GetDataDir() / pathConfigFile;
+    return pathConfigFile;
+}
 
 /** Actions when the fork triggers (MVHF-CORE-DES-TRIG-6) */
 // doBackup parameter default is true
@@ -176,10 +211,7 @@ void ActivateFork(int actualForkHeight, bool doBackup)
         // (e.g. soft-fork activated)
         FinalActivateForkHeight = actualForkHeight;
 
-        boost::filesystem::path pathBTCforkConfigFile(BTCFORK_CONF_FILENAME);
-        if (!pathBTCforkConfigFile.is_complete())
-            pathBTCforkConfigFile = GetDataDir(false) / pathBTCforkConfigFile;
-
+        boost::filesystem::path pathBTCforkConfigFile(MVFGetConfigFile());
         LogPrintf("%s: MVF: checking for existence of %s\n", __func__, pathBTCforkConfigFile.string().c_str());
 
         // remove btcfork.conf if it already exists - it shall be overwritten
@@ -188,12 +220,12 @@ void ActivateFork(int actualForkHeight, bool doBackup)
             try {
                 boost::filesystem::remove(pathBTCforkConfigFile);
             } catch (const boost::filesystem::filesystem_error& e) {
-                LogPrintf("%s: Unable to remove pidfile: %s\n", __func__, e.what());
+                LogPrintf("%s: MVF: Unable to remove %s config file: %s\n", __func__, pathBTCforkConfigFile.string().c_str(), e.what());
             }
         }
         // try to write the btcfork.conf (MVHF-CORE-DES-TRIG-10)
         LogPrintf("%s: MVF: writing %s\n", __func__, pathBTCforkConfigFile.string().c_str());
-        std::ofstream  btcforkfile(pathBTCforkConfigFile.string().c_str(), std::ios::out);
+        std::ofstream btcforkfile(pathBTCforkConfigFile.string().c_str(), std::ios::out);
         btcforkfile << "forkheight=" << FinalActivateForkHeight << "\n";
         btcforkfile << "forkid=" << FinalForkId << "\n";
 
@@ -260,4 +292,82 @@ void DeactivateFork(void)
     }
     LogPrintf("%s: MVF: disabling isMVFHardForkActive\n", __func__);
     isMVFHardForkActive = false;
+}
+
+
+/** returns the finalized path of the auto wallet backup file (MVHF-CORE-DES-WABU-2) */
+std::string MVFexpandWalletAutoBackupPath(const std::string& strDest, const std::string& strWalletFile, int BackupBlock, bool createDirs)
+{
+    boost::filesystem::path pathBackupWallet = strDest;
+
+    //if the backup destination is blank
+    if (strDest == "")
+    {
+        // then prefix it with the existing data dir and wallet filename
+        pathBackupWallet = GetDataDir() / strprintf("%s.%s",strWalletFile, autoWalletBackupSuffix);
+    }
+    else {
+        if (pathBackupWallet.is_relative())
+            // prefix existing data dir
+            pathBackupWallet = GetDataDir() / pathBackupWallet;
+
+        // if pathBackupWallet is a folder or symlink, or if it does end
+        // on a filename with an extension...
+        if (!pathBackupWallet.has_extension() || (boost::filesystem::is_directory(pathBackupWallet) && boost::filesystem::is_symlink(pathBackupWallet)))
+            // ... we assume no custom filename so append the default filename
+            pathBackupWallet /= strprintf("%s.%s",strWalletFile, autoWalletBackupSuffix);
+
+        if (pathBackupWallet.branch_path() != "" && createDirs)
+            // create directories if they don't exist
+            // MVF-BU TODO: this directory creation should be factored out
+            // so that we do not need to pass a Boolean arg and this function
+            // should not have the side effect. Marked for cleanup.
+            boost::filesystem::create_directories(pathBackupWallet.branch_path());
+    }
+
+    std::string strBackupFile = pathBackupWallet.string();
+
+    // replace # with BackupBlock number
+    boost::replace_all(strBackupFile,"@", boost::to_string_stub(BackupBlock));
+    //LogPrintf("DEBUG: strBackupFile=%s\n",strBackupFile);
+
+    return strBackupFile;
+}
+
+// get / set functions for btcforkMapArgs
+std::string MVFGetArg(const std::string& strArg, const std::string& strDefault)
+{
+    if (btcforkMapArgs.count(strArg))
+        return btcforkMapArgs[strArg];
+    return strDefault;
+}
+
+int64_t MVFGetArg(const std::string& strArg, int64_t nDefault)
+{
+    if (btcforkMapArgs.count(strArg))
+        return atoi64(btcforkMapArgs[strArg]);
+    return nDefault;
+}
+
+bool MVFGetBoolArg(const std::string& strArg, bool fDefault)
+{
+    if (btcforkMapArgs.count(strArg))
+        return InterpretBool(btcforkMapArgs[strArg]);
+    return fDefault;
+}
+
+bool MFVSoftSetArg(const std::string& strArg, const std::string& strValue)
+{
+    if (btcforkMapArgs.count(strArg))
+        return false;
+    btcforkMapArgs[strArg] = strValue;
+    return true;
+}
+
+bool MFVSoftSetBoolArg(const std::string& strArg, bool fValue)
+{
+    if (fValue)
+        return SoftSetArg(strArg, std::string("1"));
+    else
+        return SoftSetArg(strArg, std::string("0"));
 }

--- a/src/mvf-core.h
+++ b/src/mvf-core.h
@@ -107,7 +107,7 @@ extern boost::filesystem::path MVFGetConfigFile();  // get the full path to the 
 extern void ForkSetup(const CChainParams& chainparams);  // actions to perform at program setup (parameter validation etc.)
 extern void ActivateFork(int actualForkHeight, bool doBackup=true);  // actions to perform at fork triggering (MVHF-CORE-DES-TRIG-6)
 extern void DeactivateFork(void);  // actions to revert if reorg deactivates fork (MVHF-CORE-DES-TRIG-7)
-extern std::string MVFexpandWalletAutoBackupPath(const std::string& strDest, const std::string& strWalletFile, int BackupBlock, bool createDirs=true); // returns the finalized path of the auto wallet backup file (MVHF-BU-DES-WABU-2)
+extern std::string MVFexpandWalletAutoBackupPath(const std::string& strDest, const std::string& strWalletFile, int BackupBlock, bool createDirs=true); // returns the finalized path of the auto wallet backup file (MVHF-CORE-DES-WABU-2)
 extern std::string MVFGetArg(const std::string& strArg, const std::string& strDefault);
 extern int64_t MVFGetArg(const std::string& strArg, int64_t nDefault);
 extern bool MVFGetBoolArg(const std::string& strArg, bool fDefault);

--- a/src/mvf-core.h
+++ b/src/mvf-core.h
@@ -7,9 +7,18 @@
 #ifndef BITCOIN_MVF_CORE_H
 #define BITCOIN_MVF_CORE_H
 
+#include <boost/filesystem.hpp>
+
 #include "protocol.h"
 
 class CChainParams;
+
+// MVHF-CORE-DES-TRIG-10 - config file that is written when forking, and used to detect "forked" condition at start
+const char * const BTCFORK_CONF_FILENAME = "btcfork.conf";
+
+// btcfork.conf configuration key-value maps (MVF TODO: reference associated design)
+extern std::map<std::string, std::string> btcforkMapArgs;
+extern std::map<std::string, std::vector<std::string> > btcforkMapMultiArgs;
 
 extern int FinalActivateForkHeight;             // MVHF-CORE-DES-TRIG-4
 extern unsigned FinalDifficultyDropFactor;      // MVF-Core TODO: MVHF-CORE-DES-DIAD-?
@@ -83,9 +92,6 @@ static const uint256 HARDFORK_POWRESET_MAINNET = uint256S("00007ffffffffffffffff
                      HARDFORK_POWRESET_TESTNET = uint256S("007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // testnet
                      HARDFORK_POWRESET_REGTEST = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");  // regtestnet
 
-// MVHF-CORE-DES-TRIG-10 - config file that is written when forking, and used to detect "forked" condition at start
-const char * const BTCFORK_CONF_FILENAME = "btcfork.conf";
-
 // MVHF-CORE-DES-DIAD-? -force-retarget option determines  whether to actively retarget on regtest after fork happens
 // (not all tests need that, so the POW/difficulty fork related ones that do specifically invoke this option)
 const bool DEFAULT_FORCE_RETARGET = false;
@@ -97,8 +103,15 @@ const bool DEFAULT_FORCE_RETARGET = false;
 const bool DEFAULT_TRIGGER_ON_SEGWIT = true;
 
 extern std::string ForkCmdLineHelp();  // fork-specific command line option help (MVHF-CORE-DES-TRIG-8)
+extern boost::filesystem::path MVFGetConfigFile();  // get the full path to the btcfork.conf file
 extern void ForkSetup(const CChainParams& chainparams);  // actions to perform at program setup (parameter validation etc.)
 extern void ActivateFork(int actualForkHeight, bool doBackup=true);  // actions to perform at fork triggering (MVHF-CORE-DES-TRIG-6)
 extern void DeactivateFork(void);  // actions to revert if reorg deactivates fork (MVHF-CORE-DES-TRIG-7)
+extern std::string MVFexpandWalletAutoBackupPath(const std::string& strDest, const std::string& strWalletFile, int BackupBlock, bool createDirs=true); // returns the finalized path of the auto wallet backup file (MVHF-BU-DES-WABU-2)
+extern std::string MVFGetArg(const std::string& strArg, const std::string& strDefault);
+extern int64_t MVFGetArg(const std::string& strArg, int64_t nDefault);
+extern bool MVFGetBoolArg(const std::string& strArg, bool fDefault);
+extern bool MFVSoftSetArg(const std::string& strArg, const std::string& strValue);
+extern bool MFVSoftSetBoolArg(const std::string& strArg, bool fValue);
 
 #endif

--- a/src/test/mvfstandalone_tests.cpp
+++ b/src/test/mvfstandalone_tests.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2016 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <fstream>
+#include <boost/test/unit_test.hpp>
+
+#include "mvf-core.h"
+#include "mvf-btcfork_conf_parser.h"
+#include "test/test_bitcoin.h"
+
+#ifdef ENABLE_WALLET
+#include "wallet/wallet.h"
+#endif
+
+
+BOOST_FIXTURE_TEST_SUITE(mvfstandalone_tests, BasicTestingSetup)
+
+
+// tests of the wallet backup filename construction
+BOOST_AUTO_TEST_CASE(wallet_backup_path_expansion)
+{
+    std::string platform(BOOST_PLATFORM);
+
+    boost::filesystem::path datadir = GetDataDir();
+    std::string dds = datadir.string();
+    static const boost::filesystem::path abspath(GetDataDir());
+    static const boost::filesystem::path relpath("rel");
+    static const boost::filesystem::path fullpath = datadir / "w@.dat";
+    static const boost::filesystem::path userpath("/home/user/.bitcoin");
+
+    // sanity checks
+    BOOST_CHECK(abspath.is_absolute());
+    BOOST_CHECK(!abspath.is_relative());
+    BOOST_CHECK(relpath.is_relative());
+    BOOST_CHECK(!relpath.is_absolute());
+    BOOST_CHECK(!relpath.has_root_directory());
+    BOOST_CHECK(fullpath.has_filename());
+    BOOST_CHECK(userpath.has_filename());
+    BOOST_CHECK(userpath.has_extension());
+    BOOST_CHECK_EQUAL(userpath.filename(), ".bitcoin");
+    BOOST_CHECK_EQUAL(userpath.extension(), ".bitcoin");
+    BOOST_CHECK_EQUAL(userpath.extension(), userpath.filename());
+
+#ifdef ENABLE_WALLET
+    // if first arg is empty, then datadir is prefixed
+    BOOST_CHECK_EQUAL(MVFexpandWalletAutoBackupPath("", "w.dat", 0, false),
+                      datadir / "w.dat.auto.0.bak");
+
+    // if first arg is relative, then datadir is still prefixed
+    BOOST_CHECK_EQUAL(MVFexpandWalletAutoBackupPath("dir", "w.dat", 1, false),
+                      datadir / "dir" / "w.dat.auto.1.bak");
+
+    // if first arg is absolute, then datadir is not prefixed
+    BOOST_CHECK_EQUAL(MVFexpandWalletAutoBackupPath(abspath.string(), "w.dat", 2, false),
+                      abspath / "w.dat.auto.2.bak");
+
+    // if path contains @ it is replaced by height
+    BOOST_CHECK_EQUAL(MVFexpandWalletAutoBackupPath("@@@", "w@.dat", 7, false),
+                      datadir / "777" / "w7.dat.auto.7.bak");
+
+    // if first contains filename, then appending of filename is skipped
+    BOOST_CHECK_EQUAL(MVFexpandWalletAutoBackupPath(fullpath.string(), "w.dat", 6, false),
+                      datadir / "w6.dat");
+#endif
+}
+
+
+BOOST_AUTO_TEST_CASE(btcfork_conf_maps)
+{
+    btcforkMapArgs.clear();
+    btcforkMapArgs["strtest1"] = "string...";
+    // strtest2 undefined on purpose
+    btcforkMapArgs["inttest1"] = "12345";
+    btcforkMapArgs["inttest2"] = "81985529216486895";
+    // inttest3 undefined on purpose
+    btcforkMapArgs["booltest1"] = "";
+    // booltest2 undefined on purpose
+    btcforkMapArgs["booltest3"] = "0";
+    btcforkMapArgs["booltest4"] = "1";
+
+    BOOST_CHECK_EQUAL(MVFGetArg("strtest1", "default"), "string...");
+    BOOST_CHECK_EQUAL(MVFGetArg("strtest2", "default"), "default");
+    BOOST_CHECK_EQUAL(MVFGetArg("inttest1", -1), 12345);
+    BOOST_CHECK_EQUAL(MVFGetArg("inttest2", -1), 81985529216486895LL);
+    BOOST_CHECK_EQUAL(MVFGetArg("inttest3", -1), -1);
+    BOOST_CHECK_EQUAL(MVFGetBoolArg("booltest1", false), true);
+    BOOST_CHECK_EQUAL(MVFGetBoolArg("booltest2", false), false);
+    BOOST_CHECK_EQUAL(MVFGetBoolArg("booltest3", false), false);
+    BOOST_CHECK_EQUAL(MVFGetBoolArg("booltest4", false), true);
+}
+
+
+// test MVFGetConfigFile(), the MVF config (btcfork.conf) filename construction
+BOOST_AUTO_TEST_CASE(mvfgetconfigfile)
+{
+    boost::filesystem::path cfgBaseFile(BTCFORK_CONF_FILENAME);
+    BOOST_CHECK(!cfgBaseFile.is_complete());
+    BOOST_CHECK_EQUAL(MVFGetConfigFile(), (GetDataDir() / BTCFORK_CONF_FILENAME));
+}
+
+
+// test MVFReadConfigFile() which reads a config file into arg maps
+BOOST_AUTO_TEST_CASE(mvfreadconfigfile)
+{
+    boost::filesystem::path pathBTCforkConfigFile = GetTempPath() / boost::filesystem::unique_path("btcfork.conf.%%%%.txt");
+    //fprintf(stderr,"btcfork_conf_file: set config file %s\n", pathBTCforkConfigFile.string().c_str());
+    BOOST_CHECK(!boost::filesystem::exists(pathBTCforkConfigFile));
+    try
+    {
+        std::ofstream btcforkfile(pathBTCforkConfigFile.string().c_str(), std::ios::out);
+        btcforkfile << "forkheight=" << HARDFORK_HEIGHT_REGTEST << "\n";
+        btcforkfile << "forkid=" << HARDFORK_SIGHASH_ID << "\n";
+        btcforkfile << "autobackupblock=" << (HARDFORK_HEIGHT_REGTEST - 1) << "\n";
+        btcforkfile.close();
+    } catch (const std::exception& e) {
+        BOOST_ERROR("Cound not write config file " << pathBTCforkConfigFile << " : " << e.what());
+    }
+    BOOST_CHECK(boost::filesystem::exists(pathBTCforkConfigFile));
+    // clear args map and read file
+    btcforkMapArgs.clear();
+    try
+    {
+        MVFReadConfigFile(pathBTCforkConfigFile, btcforkMapArgs, btcforkMapMultiArgs);
+    } catch (const std::exception& e) {
+        BOOST_ERROR("Cound not read config file " << pathBTCforkConfigFile << " : " << e.what());
+    }
+    // check map after reading
+    BOOST_CHECK_EQUAL(atoi(btcforkMapArgs["-forkheight"]), (int)HARDFORK_HEIGHT_REGTEST);
+    BOOST_CHECK_EQUAL(atoi(btcforkMapArgs["-forkid"]), (int)HARDFORK_SIGHASH_ID);
+    BOOST_CHECK_EQUAL(atoi(btcforkMapArgs["-autobackupblock"]), (int)(HARDFORK_HEIGHT_REGTEST - 1));
+
+    // added so that we can update this test when adding new entries
+    BOOST_CHECK_EQUAL(btcforkMapArgs.size(), 3);
+
+    // cleanup
+    boost::filesystem::remove(pathBTCforkConfigFile);
+    BOOST_CHECK(!boost::filesystem::exists(pathBTCforkConfigFile));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -325,7 +325,9 @@ int LogPrintStr(const std::string &str)
 }
 
 /** Interpret string as boolean, for argument parsing */
-static bool InterpretBool(const std::string& strValue)
+// MVF-Core begin: removed static and declared extern since used by MVFGetBoolArg
+bool InterpretBool(const std::string& strValue)
+// MVF-Core end
 {
     if (strValue.empty())
         return true;

--- a/src/util.h
+++ b/src/util.h
@@ -137,6 +137,7 @@ boost::filesystem::path GetTempPath();
 void OpenDebugLog();
 void ShrinkDebugFile();
 void runCommand(const std::string& strCommand);
+extern bool InterpretBool(const std::string& strValue);  // MVF-Core: make extern, used by MVFGetBoolArg
 
 inline bool IsSwitchChar(char c)
 {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1041,46 +1041,28 @@ CAmount CWallet::GetChange(const CTransaction& tx) const
     return nChange;
 }
 
-
-
 // MVF-Core begin auto wallet backup procedure (MVHF-CORE-DES-WABU-4)
 bool CWallet::BackupWalletAuto(const std::string& strDest, int BackupBlock)
 {
-    boost::filesystem::path pathBackupWallet = strDest;
-
-    //if the backup destination is blank
-    if (strDest == "")
-    {
-        // then prefix it with the existing data dir and wallet filename
-        pathBackupWallet = GetDataDir() / strprintf("%s.%s",strWalletFile, autoWalletBackupSuffix);
-    }
-    else {
-        if (pathBackupWallet.is_relative())
-        	// prefix existing data dir
-        	pathBackupWallet = GetDataDir() / pathBackupWallet;
-
-        if (pathBackupWallet.extension() == "")
-            // no custom filename so append the default filename
-            pathBackupWallet /= strprintf("%s.%s",strWalletFile, autoWalletBackupSuffix);
-
-        if (pathBackupWallet.branch_path() != "")
-            // create directories if they don't exist
-            boost::filesystem::create_directories(pathBackupWallet.branch_path());
+    // check if backup from previous block exists
+    boost::filesystem::path pathBackupWalletPrev = MVFexpandWalletAutoBackupPath(strDest, strWalletFile, BackupBlock-1, false);
+    std::string strBackupFile = pathBackupWalletPrev.string();
+    if (boost::filesystem::exists(strBackupFile)) {
+		LogPrintf("MVF: Wallet was already backed on previous block: %s\n",strBackupFile);
+        return true;
     }
 
-    std::string strBackupFile = pathBackupWallet.string();
-
-    // replace # with BackupBlock number
-    boost::replace_all(strBackupFile,"@", boost::to_string_stub(BackupBlock));
-    //LogPrintf("DEBUG: strBackupFile=%s\n",strBackupFile);
-
+    // no previous-block backup found, so carry on...
+    // get final backup path (and create directories for it as needed)
+    boost::filesystem::path pathBackupWallet = MVFexpandWalletAutoBackupPath(strDest, strWalletFile, BackupBlock);
     // rename with .old suffix if target already exists
+    strBackupFile = pathBackupWallet.string();
     if (boost::filesystem::exists(strBackupFile))
         boost::filesystem::rename(strBackupFile,strprintf("%s.%s.old",strBackupFile,GetTime()));
 
     // call common backup wallet function
 	if (BackupWallet(*this, strBackupFile))
-		LogPrintf("Wallet automatically backed up to: %s\n",strBackupFile);
+		LogPrintf("MVF: Wallet automatically backed up to: %s\n",strBackupFile);
 	else
 		// backup failed
 		return false;


### PR DESCRIPTION
This implements reading of the values in the btcfork.conf file on startup if it is present.

The idea here was that when the fork happens, this file is written out with the key parameters used to fork. This helps the client to recognize at startup that it has forked previously, and can then initialize itself correctly.

Ultimately, the user will be requested to transfer some of the final settings to his bitcoin.conf file, and can then remove the btcfork.conf file entirely. This part is not yet implemented.