### PR TITLE
fix wallet auto backup filename expansion bug which causes mvfstandalone_tests to fail

### DIFF
--- a/src/mvf-core.cpp
+++ b/src/mvf-core.cpp
@@ -313,7 +313,7 @@ std::string MVFexpandWalletAutoBackupPath(const std::string& strDest, const std:
 
         // if pathBackupWallet is a folder or symlink, or if it does end
         // on a filename with an extension...
-        if (!pathBackupWallet.has_extension() || (boost::filesystem::is_directory(pathBackupWallet) && boost::filesystem::is_symlink(pathBackupWallet)))
+        if (!pathBackupWallet.has_extension() || boost::filesystem::is_directory(pathBackupWallet) || boost::filesystem::is_symlink(pathBackupWallet))
             // ... we assume no custom filename so append the default filename
             pathBackupWallet /= strprintf("%s.%s",strWalletFile, autoWalletBackupSuffix);
 


### PR DESCRIPTION
First seen on MVF-BU Travis build, and merged since the code definitely seemed buggy even though it somehow passed Travis tests on MVF-Core.