### PR TITLE
fix walletbackupauto nosoftfork reliability

### DIFF
--- a/src/mvf-core.cpp
+++ b/src/mvf-core.cpp
@@ -272,6 +272,7 @@ void ActivateFork(int actualForkHeight, bool doBackup)
             // auto backup was already made pre-fork - emit parameters
             btcforkfile << "autobackupblock=" << GetArg("-autobackupblock", FinalActivateForkHeight - 1) << "\n";
             LogPrintf("%s: MVF: height-based auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalActivateForkHeight - 1));
+            fAutoBackupDone = true;  // added because otherwise backup can sometimes be re-done
         }
 
         // close fork parameter file
@@ -320,7 +321,7 @@ std::string MVFexpandWalletAutoBackupPath(const std::string& strDest, const std:
 
         if (pathBackupWallet.branch_path() != "" && createDirs)
             // create directories if they don't exist
-            // MVF-BU TODO: this directory creation should be factored out
+            // MVF-Core TODO: this directory creation should be factored out
             // so that we do not need to pass a Boolean arg and this function
             // should not have the side effect. Marked for cleanup.
             boost::filesystem::create_directories(pathBackupWallet.branch_path());

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -142,7 +142,7 @@ unsigned int GetMVFNextWorkRequired(const CBlockIndex* pindexLast, const CBlockH
             }
             return pindexLast->nBits;
         }
-        LogPrintf("MVF RETARGET");
+        LogPrintf("MVF RETARGET\n");
         return CalculateMVFNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
 
     } // end fork reset
@@ -225,7 +225,6 @@ unsigned int CalculateMVFResetWorkRequired(const CBlockIndex* pindexLast, int64_
 
     // TODO : Determine best reset formula
     // currently we drop difficulty by a factor (see help for -diffdrop option)
-    // use same formula as standard
     int64_t nActualTimespan = pindexLast->GetBlockTime() - nFirstBlockTime;
     // used reduced target time span
     int64_t nTargetTimespan = nActualTimespan / FinalDifficultyDropFactor;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1047,6 +1047,7 @@ bool CWallet::BackupWalletAuto(const std::string& strDest, int BackupBlock)
     // check if backup from previous block exists
     boost::filesystem::path pathBackupWalletPrev = MVFexpandWalletAutoBackupPath(strDest, strWalletFile, BackupBlock-1, false);
     std::string strBackupFile = pathBackupWalletPrev.string();
+    LogPrintf("MVF: BackupWalletAuto: checking for existence of backup from previous block at location: %s\n",strBackupFile.c_str());
     if (boost::filesystem::exists(strBackupFile)) {
 		LogPrintf("MVF: Wallet was already backed on previous block: %s\n",strBackupFile);
         return true;


### PR DESCRIPTION
walletbackupauto.py had a tendency to fail in the last step (where it is checking for non-creation of duplicate backup in case of soft-fork activation)

This was only observed on MVF-Core, and probably triggered by a difference in the way blocks are sometimes transmitted to the restarted node.