### PR TITLE
BFGtest - btc fork genesis testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -24,7 +24,7 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
     txNew.nVersion = 1;
     txNew.vin.resize(1);
     txNew.vout.resize(1);
-    txNew.vin[0].scriptSig = CScript() << 486604799 << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));
+    txNew.vin[0].scriptSig = CScript() << 0x1d00ffff << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));  // MVF-Core: replace magic number by more recognizable nBits value
     txNew.vout[0].nValue = genesisReward;
     txNew.vout[0].scriptPubKey = genesisOutputScript;
 
@@ -247,6 +247,101 @@ public:
 };
 static CTestNetParams testNetParams;
 
+// MVF-Core begin: added btcforks genesis testnet (bfgtest)
+class CBFGTestParams : public CChainParams {
+public:
+    CBFGTestParams() {
+        strNetworkID = "bfgtest";  // btcforks genesis testnet
+        consensus.nSubsidyHalvingInterval = 210000;
+        consensus.nMajorityEnforceBlockUpgrade = 750;
+        consensus.nMajorityRejectBlockOutdated = 950;
+        consensus.nMajorityWindow = 1000;
+        consensus.BIP34Height = 10;
+        consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
+        consensus.powLimit = uint256S("0000007fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");  // 0x1d7fffff
+        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
+        consensus.nPowTargetSpacing = 10 * 60;
+        consensus.fPowAllowMinDifficultyBlocks = false;
+        consensus.fPowNoRetargeting = false;
+        consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
+        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+        // MVF-Core begin added soft-fork deployments identical with testnet, for consistency
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
+
+        // Deployment of BIP68, BIP112, and BIP113.
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1456790400; // March 1st, 2016
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
+        // MVF-Core end
+
+        // MVF-Core begin: added deployment of BIP141/143/147 (MVHF-BU-DES-TRIG-2)
+        // these have been shifted on BFG testnet
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1483228800; // Jan 1st, 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1520035200; // Mar 3rd, 2018
+        // MVF-Core end
+        /**
+         * The message start string is designed to be unlikely to occur in normal data.
+         * The characters *should be* rarely used upper ASCII, not valid as UTF-8, and produce
+         * a large 32-bit integer with any alignment.
+         * For BFG testnet, they have not been chosen very carefully, so may
+         * fail some of these criteria.
+         */
+        pchMessageStart[0] = 0xda;
+        pchMessageStart[1] = 0xe3;
+        pchMessageStart[2] = 0xc7;
+        pchMessageStart[3] = 0xd0;
+        vAlertPubKey = ParseHex("04b20ea6bc4d67bf9fa4bf9186df1b1d983ad186ac712ccb5191a738177e430c0e3ece450c0ca1021abef4c28b6ec6c089da84f1fc7b165be7ed1bdb3f292cdbd0");
+        nDefaultPort = 19888;
+        nMaxTipAge = 30 * 24 * 60 * 60;  // this chain is not consistently mined
+        nPruneAfterHeight = 100000;
+
+        // script below is equivalent to "76a914 hash160(compressed pubkey) 88ac"
+        // which decodes to "OP_DUP OP_HASH160 d7b6e7527ebbcb86571544d2d934867349baccf3 OP_EQUALVERIFY OP_CHECKSIG"
+        const CScript genesisOutputScript = CScript() << ParseHex("76a914d7b6e7527ebbcb86571544d2d934867349baccf388ac");
+
+        // replace with generated genesis block (nNonce) - the actual block can be mined at higher difficulty than the given nBits
+        genesis = CreateGenesisBlock("To boldly fork where no-one has forked before", genesisOutputScript, 1481996048, 3180522, 0x1d7fffff, 0x20000000, CAmount(5000000000));
+        consensus.hashGenesisBlock = genesis.GetHash();
+
+        // update these with the mined genesis params
+        assert(consensus.hashGenesisBlock == uint256S("0x0000004557d7deb53c5642a1df3a4becd7d5e748f409d5d68a8677e04cc7cb6c"));
+        assert(genesis.hashMerkleRoot == uint256S("0x9f4ec9d5f23fb06a65c461a0d63dc8d28133bb8873233c88240fbbad6fe3c770"));
+
+        // MVF-BU begin disabled for now
+        //vSeeds.push_back(CDNSSeedData("btcc.com", "seed.btcc.com"));    // BTCC
+        //vSeeds.push_back(CDNSSeedData("bitnodes.io", "seed.bitnodes.io"));      // Bitnodes (Addy Yeow)
+        //vSeeds.push_back(CDNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be")); // Pieter Wuille
+        // MVF-BU end
+
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
+        base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
+        base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x35)(0x87)(0xCF).convert_to_container<std::vector<unsigned char> >();
+        base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x35)(0x83)(0x94).convert_to_container<std::vector<unsigned char> >();
+
+        vFixedSeeds = std::vector<SeedSpec6>();
+
+        fMiningRequiresPeers = true;
+        fDefaultConsistencyChecks = false;
+        fRequireStandard = true;
+        fMineBlocksOnDemand = false;
+        fTestnetToBeDeprecatedFieldRPC = false;
+
+        checkpointData = (CCheckpointData){
+            boost::assign::map_list_of
+            ( 0, uint256S("0000000000000000000000000000000000000000000000000000000000000000")),
+            0,
+            0,
+            0
+        };
+    }
+};
+CBFGTestParams bfgTestParams;
+// MVF-Core end
+
 /**
  * Regression test
  */
@@ -331,6 +426,8 @@ CChainParams& Params(const std::string& chain)
             return mainParams;
     else if (chain == CBaseChainParams::TESTNET)
             return testNetParams;
+    else if (chain == CBaseChainParams::BFGTEST)
+            return bfgTestParams;
     else if (chain == CBaseChainParams::REGTEST)
             return regTestParams;
     else

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -13,11 +13,13 @@
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";
 const std::string CBaseChainParams::REGTEST = "regtest";
+const std::string CBaseChainParams::BFGTEST = "bfgtest";  // MVF-Core
 
 void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
 {
     strUsage += HelpMessageGroup(_("Chain selection options:"));
     strUsage += HelpMessageOpt("-testnet", _("Use the test chain"));
+    strUsage += HelpMessageOpt("-bfgtest", _("Use the btcforks genesis test chain"));  // MVF-Core
     if (debugHelp) {
         strUsage += HelpMessageOpt("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
                                    "This is intended for regression testing tools and app development.");
@@ -51,6 +53,22 @@ public:
 };
 static CBaseTestNetParams testNetParams;
 
+// MVF-Core begin
+/**
+ * BFG network
+ */
+class CBaseBFGTestParams : public CBaseChainParams
+{
+public:
+    CBaseBFGTestParams()
+    {
+        nRPCPort = 19887;
+        strDataDir = "bfgtest";
+    }
+};
+static CBaseBFGTestParams bfgTestParams;
+// MVF-Core end
+
 /*
  * Regression test
  */
@@ -81,6 +99,10 @@ CBaseChainParams& BaseParams(const std::string& chain)
         return testNetParams;
     else if (chain == CBaseChainParams::REGTEST)
         return regTestParams;
+    // MVF-Core begin
+    else if (chain == CBaseChainParams::BFGTEST)
+        return bfgTestParams;
+    // MVF-Core end
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }
@@ -94,6 +116,7 @@ std::string ChainNameFromCommandLine()
 {
     bool fRegTest = GetBoolArg("-regtest", false);
     bool fTestNet = GetBoolArg("-testnet", false);
+    bool fBFGTest = GetBoolArg("-bfgtest", false);  // MVF-Core
 
     if (fTestNet && fRegTest)
         throw std::runtime_error("Invalid combination of -regtest and -testnet.");
@@ -101,6 +124,10 @@ std::string ChainNameFromCommandLine()
         return CBaseChainParams::REGTEST;
     if (fTestNet)
         return CBaseChainParams::TESTNET;
+    // MVF-Core begin
+    if (fBFGTest)
+        return CBaseChainParams::BFGTEST;
+    // MVF-Core end
     return CBaseChainParams::MAIN;
 }
 

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -19,6 +19,7 @@ public:
     static const std::string MAIN;
     static const std::string TESTNET;
     static const std::string REGTEST;
+    static const std::string BFGTEST;  // MVF-Core
 
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }

--- a/src/mvf-core.cpp
+++ b/src/mvf-core.cpp
@@ -48,7 +48,7 @@ std::string ForkCmdLineHelp()
     strUsage += HelpMessageOpt("-autobackupblock=<n>", _("Specify the block number that triggers the automatic wallet backup. Default: forkheight-1"));
 
     // fork height parameter (MVHF-CORE-DES-TRIG-1)
-    strUsage += HelpMessageOpt("-forkheight=<n>", strprintf(_("Block height at which to fork on active network (integer). Defaults (also minimums): mainnet:%u,testnet=%u,regtest=%u"), (unsigned)HARDFORK_HEIGHT_MAINNET, (unsigned)HARDFORK_HEIGHT_TESTNET, (unsigned)HARDFORK_HEIGHT_REGTEST));
+    strUsage += HelpMessageOpt("-forkheight=<n>", strprintf(_("Block height at which to fork on active network (integer). Defaults (also minimums): mainnet:%u,testnet=%u,regtest=%u,bfgtest=%u"), (unsigned)HARDFORK_HEIGHT_MAINNET, (unsigned)HARDFORK_HEIGHT_TESTNET, (unsigned)HARDFORK_HEIGHT_REGTEST, (unsigned)HARDFORK_HEIGHT_BFGTEST));
 
     // fork id (MVHF-CORE-DES-CSIG-1)
     strUsage += HelpMessageOpt("-forkid=<n>", strprintf(_("Fork id to use for signature change. Value must be between 0 and %d. Default is 0x%06x (%u)"), (unsigned)MAX_HARDFORK_SIGHASH_ID, (unsigned)HARDFORK_SIGHASH_ID, (unsigned)HARDFORK_SIGHASH_ID));
@@ -74,6 +74,8 @@ void ForkSetup(const CChainParams& chainparams)
         defaultForkHeightForNetwork = HARDFORK_HEIGHT_TESTNET;
     else if (activeNetworkID == CBaseChainParams::REGTEST)
         defaultForkHeightForNetwork = HARDFORK_HEIGHT_REGTEST;
+    else if (activeNetworkID == CBaseChainParams::BFGTEST)
+        defaultForkHeightForNetwork = HARDFORK_HEIGHT_BFGTEST;
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, activeNetworkID));
 

--- a/src/mvf-core.h
+++ b/src/mvf-core.h
@@ -27,6 +27,7 @@ HARDFORK_MAX_BLOCK_SIZE = 2000000,   // the fork's new maximum block size, in by
 HARDFORK_HEIGHT_MAINNET =  666666,   // operational network trigger height
 HARDFORK_HEIGHT_TESTNET = 9999999,   // public test network trigger height
 HARDFORK_HEIGHT_REGTEST =  999999,   // regression test network (local)  trigger height
+HARDFORK_HEIGHT_BFGTEST = 9999999,   // btcforks genesis test network trigger height
 
 // MVHF-CORE-DES-DIAD-3 / MVHF-CORE-DES-DIAD-4
 // period (in blocks) from fork activation until retargeting returns to normal
@@ -37,6 +38,7 @@ HARDFORK_RETARGET_BLOCKS = 25920,    // 180*144 blocks
 HARDFORK_PORT_MAINNET = 9542,        // default post-fork port on operational network (mainnet)
 HARDFORK_PORT_TESTNET = 9543,        // default post-fork port on public test network (testnet)
 HARDFORK_PORT_REGTEST = 19655,       // default post-fork port on local regression test network (regtestnet)
+HARDFORK_PORT_BFGTEST = 19988,       // default post-fork port on btcforks genesis test network (bfgtest)
 
 // MVHF-CORE-DES-CSIG-1 - signature change parameter defaults
 HARDFORK_SIGHASH_ID = 0x555000,      // 3 byte fork id that is left-shifted by 8 bits and then ORed with the SIGHASHes
@@ -61,6 +63,7 @@ static const CMessageHeader::MessageStartChars pchMessageStart_HardForkMainnet  
 // values to which powLimit is reset at fork time on various networks (MVHF-CORE-DES-DIAD-2):
 static const uint256 HARDFORK_POWRESET_MAINNET = uint256S("00007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // mainnet
                      HARDFORK_POWRESET_TESTNET = uint256S("007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // testnet
+                     HARDFORK_POWRESET_BFGTEST = uint256S("007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // bfgtest
                      HARDFORK_POWRESET_REGTEST = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");  // regtestnet
 
 // MVHF-CORE-DES-TRIG-10 - config file that is written when forking, and used to detect "forked" condition at start


### PR DESCRIPTION
This commit introduces the BFG test network  (command line option: `-bfgtest`) .

Name: BFG = Bitcoin Forks Genesis 
Motto: "_To boldly fork where no-one has forked before_"
Default P2P Network Port: 19888
Default RPC Port: 19887
Halving interval: as per regular testnet3
POW limit: 0x1d7fffff
Network magic (message start bytes): 0xda 0xe3 0xc7 0xd0
base58Prefixes: same as other public testnets

Rationale: A separate test network is deemed to be a good idea because BTCfork may want to do tests that could be considered disruptive to other networks. We want to be able to do so in relative peace (ok, we cannot prevent others from coming to this network and interfering with our tests, but at least then we're not intruding). Besides, I considered it necessary and fun to learn how to mine a genesis block.

Notes:

- The default fork height has been set to a dummy value (9999999) so that various tests can set their own fork heights using `-forkheight=X` as needed.

- Deployment of SegWit BIPs (141/143/147) has been time-shifted on BFGtest to start on Jan 1st 2017 and end on Mar 3rd 2018. Since this is our own playground, we can decide to start SW a little later, this gives more time for us to do tests before it can activate.

- We may need to reset this test network after some tests - the precise modalities around that are still TBD.

- There are no seed nodes (DNS / static) defined initially. This may change in subsequent code updates.