### PR TITLE
add missing network style for bfgtest network

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -50,5 +50,6 @@ static const int MAX_URI_LENGTH = 255;
 #define QAPP_ORG_DOMAIN "bitcoin.org"
 #define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
 #define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
+#define QAPP_APP_NAME_BFGTEST "Bitcoin-Qt-bfgtest"  // MVF-Core added (MVF-Core TODO: reference to design)
 
 #endif // BITCOIN_QT_GUICONSTANTS_H

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -17,6 +17,7 @@ static const struct {
 } network_styles[] = {
     {"main", QAPP_APP_NAME_DEFAULT, 0, 0, ""},
     {"test", QAPP_APP_NAME_TESTNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[testnet]")},
+    {"bfgtest", QAPP_APP_NAME_BFGTEST, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[bfgtest]")},  // MVF-Core added  (MVF-Core TODO: reference to design)
     {"regtest", QAPP_APP_NAME_TESTNET, 160, 30, "[regtest]"}
 };
 static const unsigned network_styles_count = sizeof(network_styles)/sizeof(*network_styles);


### PR DESCRIPTION
This was causing the assertion to be raised in src/qt/bitcoin.cpp:616:

assert(!networkStyle.isNull());