### PR TITLE
[WIP] Use original difficulty calc if no difficulty reset requested

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -15,8 +15,9 @@
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
-    // MVF-Core begin difficulty re-targeting
+    // MVF-Core begin difficulty re-targeting if diff reset was made (drop factor != 1)
     if (params.MVFisWithinRetargetPeriod(pindexLast->nHeight+1))
+    if (FinalDifficultyDropFactor != 1 && params.MVFisWithinRetargetPeriod(pindexLast->nHeight+1))
         return GetMVFNextWorkRequired(pindexLast, pblock, params);
     // MVF-Core end
 


### PR DESCRIPTION
If dropfactor=1, i.e. no difficulty reset was requested, then there should be no need to use the adjusted retargeting schedule - just keep using the historic retargeting code path.

This is WIP as it needs testing. Currently the tests use the built-in default drop factors.